### PR TITLE
Alphabetic sort and added page type attribute properties

### DIFF
--- a/PageTypeBuilder/Configuration/PageTypeBuilderConfiguration.cs
+++ b/PageTypeBuilder/Configuration/PageTypeBuilderConfiguration.cs
@@ -31,5 +31,14 @@ namespace PageTypeBuilder.Configuration
                 return "http://PageTypeBuilder.Configuration.PageTypeBuilderConfiguration";
             }
         }
+
+		[ConfigurationProperty("enablePageTypeAlphabeticSortOverride", IsRequired = false)]
+		public virtual bool EnablePageTypeAlphabeticSortOverride
+		{
+			get
+			{
+				return (bool)this["enablePageTypeAlphabeticSortOverride"];
+			}
+		}
     }
 }

--- a/PageTypeBuilder/PageTypeAttribute.cs
+++ b/PageTypeBuilder/PageTypeAttribute.cs
@@ -57,5 +57,9 @@ namespace PageTypeBuilder
         public virtual int DefaultFrameID { get; set; }
 
         public virtual Type[] AvailablePageTypes { get; set; }
+
+		public virtual Type[] AvailablePageTypesIncludeSubclasses { get; set; }
+
+		public virtual Type[] ExcludePageTypes { get; set; }
     }
 }

--- a/PageTypeBuilder/Synchronization/PageTypeSynchronizer.cs
+++ b/PageTypeBuilder/Synchronization/PageTypeSynchronizer.cs
@@ -56,6 +56,11 @@ namespace PageTypeBuilder.Synchronization
                 UpdatePageTypes(pageTypeDefinitions);
 
                 UpdatePageTypePropertyDefinitions(pageTypeDefinitions);
+
+				if (_configuration.EnablePageTypeAlphabeticSortOverride)
+				{
+					SortPageTypesAlphabetically();
+				}
             }
 
             AddPageTypesToResolver(pageTypeDefinitions);
@@ -111,7 +116,12 @@ namespace PageTypeBuilder.Synchronization
                 PageTypePropertyUpdater.UpdatePageTypePropertyDefinitions(pageType, definition);
             }
         }
-        
+
+		protected internal virtual void SortPageTypesAlphabetically()
+		{
+			PageTypeUpdater.SortPageTypesAlphabetically();
+		}
+
         protected internal virtual PageTypeResolver PageTypeResolver { get; set; }
 
         protected internal virtual TabLocator TabLocator { get; set; }

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+testing.

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-testing.


### PR DESCRIPTION
AvailablePageTypesIncludeSubclasses:

Works like the AvailablePageTypes attribute but with an important difference. It will also include all subclasses of the specified page type(s).

ExcludePageTypes:

The page types specified will be removed from the array of available page types.

enablePageTypeAlphabeticSortOverride:

This is a configuration attribute where you can specify if you want PageTypeBuilder to sort your page types alphabetically for you.

Add the following lines to your configuration file.

<section name="pageTypeBuilder" type="PageTypeBuilder.Configuration.PageTypeBuilderConfiguration, PageTypeBuilder"/>
<pageTypeBuilder enablePageTypeAlphabeticSortOverride="true" />
