### PR TITLE
PropertyGroup extension methods

### DIFF
--- a/PageTypeBuilder.Tests/Discovery/PageTypePropertyLocatorTests.cs
+++ b/PageTypeBuilder.Tests/Discovery/PageTypePropertyLocatorTests.cs
@@ -41,17 +41,29 @@
             Type pageTypeType = typeof(TestPageTypeWithPropertyGroups);
             IEnumerable<PageTypePropertyDefinition> propertyDefinitions = definitionLocator.GetPageTypePropertyDefinitions(pageType, pageTypeType);
 
-            Assert.Equal(7, propertyDefinitions.Count());
+            Assert.Equal(16, propertyDefinitions.Count());
 
             List<Defintion> defintions = new List<Defintion>
              {
                  new Defintion { EditCaption = "Property one", SortOrder = 100, Name = "LongStringProperty" },
+
                  new Defintion { EditCaption = "Image one - Image Url", SortOrder = 400, Name = "ImageOne-ImageUrl" },
                  new Defintion { EditCaption = "Image one - Alt text", SortOrder = 410, Name = "ImageOne-AltText" },
+                 new Defintion { EditCaption = "Image one - Nullable test int property", SortOrder = 420, Name = "ImageOne-NullableTestIntProperty" },
+                 new Defintion { EditCaption = "Image one - int test property", SortOrder = 430, Name = "ImageOne-IntTestProperty" },
+                 new Defintion { EditCaption = "Image one - string test property", SortOrder = 440, Name = "ImageOne-StringTestProperty" },
+
                  new Defintion { EditCaption = "Image two - Image Url", SortOrder = 500, Name = "ImageTwo-ImageUrl" },
                  new Defintion { EditCaption = "Image two - Alt text", SortOrder = 510, Name = "ImageTwo-AltText" },
+                 new Defintion { EditCaption = "Image two - Nullable test int property", SortOrder = 520, Name = "ImageTwo-NullableTestIntProperty" },
+                 new Defintion { EditCaption = "Image two - int test property", SortOrder = 530, Name = "ImageTwo-IntTestProperty" },
+                 new Defintion { EditCaption = "Image two - string test property", SortOrder = 540, Name = "ImageTwo-StringTestProperty" },
+
                  new Defintion { EditCaption = "Image three - Image Url", SortOrder = 600, Name = "ImageThree-ImageUrl" },
-                 new Defintion { EditCaption = "Image three - Alt text", SortOrder = 610, Name = "ImageThree-AltText" }
+                 new Defintion { EditCaption = "Image three - Alt text", SortOrder = 610, Name = "ImageThree-AltText" }, 
+                 new Defintion { EditCaption = "Image three - Nullable test int property", SortOrder = 620, Name = "ImageThree-NullableTestIntProperty" },
+                 new Defintion { EditCaption = "Image three - int test property", SortOrder = 630, Name = "ImageThree-IntTestProperty" },
+                 new Defintion { EditCaption = "Image three - string test property", SortOrder = 640, Name = "ImageThree-StringTestProperty" }
              };
 
             foreach (PageTypePropertyDefinition pageTypePropertyDefinition in propertyDefinitions)

--- a/PageTypeBuilder.Tests/PageDataExtensionMethodsTests.cs
+++ b/PageTypeBuilder.Tests/PageDataExtensionMethodsTests.cs
@@ -161,7 +161,7 @@ namespace PageTypeBuilder.Tests
             typedPageData.Property.Add(propertyName, new PropertyNumber(propertyValue.Value));
 
 
-            int returnedValue = typedPageData.GetPropertyValue<TestPageType, int>(page => page.NullableIntTestProperty, false);
+            int returnedValue = typedPageData.GetPropertyValue<TestPageType, int?>(page => page.NullableIntTestProperty, false).Value;
 
             Assert.Equal<int>(propertyValue.Value, returnedValue);
         }
@@ -178,7 +178,7 @@ namespace PageTypeBuilder.Tests
             typedPageData.Property.Add(propertyName, new PropertyNumber(propertyValue.Value));
 
 
-            int returnedValue = typedPageData.GetPropertyValue<TestPageType, int>(page => page.NullableIntTestProperty, true);
+            int returnedValue = typedPageData.GetPropertyValue<TestPageType, int?>(page => page.NullableIntTestProperty, true).Value;
 
             Assert.Equal<int>(propertyValue.Value, returnedValue);
         }

--- a/PageTypeBuilder.Tests/PageTypeBuilder.Tests.csproj
+++ b/PageTypeBuilder.Tests/PageTypeBuilder.Tests.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Helpers\PageTypeUpdaterFactory.cs" />
     <Compile Include="Helpers\TabDefinitionUpdaterFactory.cs" />
     <Compile Include="Helpers\TabLocatorFactory.cs" />
+    <Compile Include="PageTypePropertyGroupExtensionMethodsTests.cs" />
     <Compile Include="PageTypeWithCustomAttribute.cs" />
     <Compile Include="Synchronization\PageDefinitionSynchronizationEngineTests\PageDefinitionSynchronizationEngineTestsUtility.cs" />
     <Compile Include="Synchronization\PageDefinitionSynchronizationEngineTests\UpdatePageDefinitionTests.cs" />

--- a/PageTypeBuilder.Tests/PageTypePropertyGroupExtensionMethodsTests.cs
+++ b/PageTypeBuilder.Tests/PageTypePropertyGroupExtensionMethodsTests.cs
@@ -1,0 +1,234 @@
+﻿using System;
+using System.Linq.Expressions;
+using EPiServer.Core;
+using PageTypeBuilder.Activation;
+using Xunit;
+
+namespace PageTypeBuilder.Tests
+{
+    public class PageTypePropertyGroupsExtensionMethodsTests
+    {
+        [Fact]
+        public void GivenValue_SetPropertyGroupPropertyValue_SetsPropertyValue()
+        {
+            TestPageTypeWithPropertyGroups typedPageData = new TestPageTypeWithPropertyGroups();
+            typedPageData = new TypedPageActivator().CreateAndPopulateTypedInstance(typedPageData, typeof(TestPageTypeWithPropertyGroups)) as TestPageTypeWithPropertyGroups;
+            string propertyName = typedPageData.ImageOne.GetPropertyGroupPropertyName(propertyGroup => propertyGroup.ImageUrl);
+
+            typedPageData.Property.Add(propertyName, new PropertyString(""));
+            string valueToSet = "Test";
+
+            typedPageData.ImageOne.SetPropertyGroupPropertyValue(propertyGroup => propertyGroup.ImageUrl, valueToSet);
+
+            Assert.Equal<string>(valueToSet, typedPageData.ImageOne.ImageUrl as string);
+        }
+
+        [Fact]
+        public void GetPropertyGroupPropertyValue_ReturnsPropertyValue()
+        {
+            TestPageTypeWithPropertyGroups typedPageData = new TestPageTypeWithPropertyGroups();
+            typedPageData = new TypedPageActivator().CreateAndPopulateTypedInstance(typedPageData, typeof(TestPageTypeWithPropertyGroups)) as TestPageTypeWithPropertyGroups;
+            string propertyName = typedPageData.ImageOne.GetPropertyGroupPropertyName(propertyGroup => propertyGroup.ImageUrl);
+            string propertyValue = "Test";
+            typedPageData.Property.Add(propertyName, new PropertyString(propertyValue));
+
+            string returnedValue = typedPageData.ImageOne.GetPropertyGroupPropertyValue(propertyGroup => propertyGroup.ImageUrl);
+
+            Assert.Equal<string>(propertyValue, returnedValue);
+        }
+
+
+        [Fact]
+        public void GetPropertyGroupProperty_ReturnsProperty()
+        {
+            TestPageTypeWithPropertyGroups typedPageData = new TestPageTypeWithPropertyGroups();
+            typedPageData = new TypedPageActivator().CreateAndPopulateTypedInstance(typedPageData, typeof(TestPageTypeWithPropertyGroups)) as TestPageTypeWithPropertyGroups;
+            string propertyName = typedPageData.ImageOne.GetPropertyGroupPropertyName(propertyGroup => propertyGroup.ImageUrl);
+            string propertyValue = "Test";
+            typedPageData.Property.Add(propertyName, new PropertyString(propertyValue));
+
+            PropertyData propertyData = typedPageData.ImageOne.GetPropertyGroupProperty(propertyGroup => propertyGroup.ImageUrl);
+            Assert.Equal(typedPageData.Property[propertyName], propertyData);
+
+            PropertyString propertyString = typedPageData.ImageOne.GetPropertyGroupProperty<Image, PropertyString>(propertyGroup => propertyGroup.ImageUrl);
+            Assert.Equal(typedPageData.Property[propertyName], propertyString);
+        }
+
+        [Fact]
+        public void GivenPropertyIsReferenceTypeAndNull_GetPropertyGroupPropertyValue_ReturnsNull()
+        {
+            TestPageTypeWithPropertyGroups typedPageData = new TestPageTypeWithPropertyGroups();
+            typedPageData = new TypedPageActivator().CreateAndPopulateTypedInstance(typedPageData, typeof(TestPageTypeWithPropertyGroups)) as TestPageTypeWithPropertyGroups;
+            string propertyName = typedPageData.ImageOne.GetPropertyGroupPropertyName(propertyGroup => propertyGroup.ImageUrl);
+            typedPageData.Property.Add(propertyName, new PropertyString());
+
+            string returnedValue = typedPageData.ImageOne.GetPropertyGroupPropertyValue(propertyGroup => propertyGroup.ImageUrl);
+
+            Assert.Null(returnedValue);
+        }
+
+        [Fact]
+        public void GivenPropertyIsNullableTypeAndNull_GetPropertyGroupPropertyValue_ReturnsNullValue()
+        {
+            TestPageTypeWithPropertyGroups typedPageData = new TestPageTypeWithPropertyGroups();
+            typedPageData = new TypedPageActivator().CreateAndPopulateTypedInstance(typedPageData, typeof(TestPageTypeWithPropertyGroups)) as TestPageTypeWithPropertyGroups;
+            string propertyName = typedPageData.ImageOne.GetPropertyGroupPropertyName(propertyGroup => propertyGroup.NullableTestIntProperty);
+            typedPageData.Property.Add(propertyName, new PropertyNumber());
+
+            int? returnedValue = typedPageData.ImageOne.GetPropertyGroupPropertyValue(propertyGroup => propertyGroup.NullableTestIntProperty);
+
+            Assert.False(returnedValue.HasValue);
+        }
+
+        [Fact]
+        public void GivenPropertyIsValueTypeAndNull_GetPropertyGroupPropertyValue_ThrowsException()
+        {
+            TestPageTypeWithPropertyGroups typedPageData = new TestPageTypeWithPropertyGroups();
+            typedPageData = new TypedPageActivator().CreateAndPopulateTypedInstance(typedPageData, typeof(TestPageTypeWithPropertyGroups)) as TestPageTypeWithPropertyGroups;
+            string propertyName = typedPageData.ImageOne.GetPropertyGroupPropertyName(propertyGroup => propertyGroup.IntTestProperty);
+            typedPageData.Property.Add(propertyName, new PropertyNumber());
+
+            Exception exception = Record.Exception(() => typedPageData.ImageOne.GetPropertyGroupPropertyValue(propertyGroup => propertyGroup.IntTestProperty));
+
+            Assert.NotNull(exception);
+        }
+
+        [Fact]
+        public void GivenValueExistsAndIncludeDynamicIsFalse_GetPropertyGroupPropertyValue_ReturnsPropertyValue()
+        {
+            TestPageTypeWithPropertyGroups typedPageData = new TestPageTypeWithPropertyGroups();
+            typedPageData = new TypedPageActivator().CreateAndPopulateTypedInstance(typedPageData, typeof(TestPageTypeWithPropertyGroups)) as TestPageTypeWithPropertyGroups;
+            string propertyName = typedPageData.ImageOne.GetPropertyGroupPropertyName(propertyGroup => propertyGroup.StringTestProperty);
+
+            string propertyValue = "Test";
+            typedPageData.Property.Add(propertyName, new PropertyString(propertyValue));
+
+            string returnedValue = typedPageData.ImageOne.GetPropertyGroupPropertyValue(propertyGroup => propertyGroup.StringTestProperty, false);
+
+            Assert.Equal<string>(propertyValue, returnedValue);
+        }
+
+        [Fact]
+        public void GivenValueExistsAndIncludeDynamicIsTrue_GetPropertyGroupPropertyValue_ReturnsPropertyValue()
+        {
+            TestPageTypeWithPropertyGroups typedPageData = new TestPageTypeWithPropertyGroups();
+            typedPageData = new TypedPageActivator().CreateAndPopulateTypedInstance(typedPageData, typeof(TestPageTypeWithPropertyGroups)) as TestPageTypeWithPropertyGroups;
+            string propertyName = typedPageData.ImageOne.GetPropertyGroupPropertyName(propertyGroup => propertyGroup.StringTestProperty);
+            string propertyValue = "Test";
+            typedPageData.Property.Add(propertyName, new PropertyString(propertyValue));
+
+
+            string returnedValue = typedPageData.ImageOne.GetPropertyGroupPropertyValue(propertyGroup => propertyGroup.StringTestProperty, true);
+
+            Assert.Equal<string>(propertyValue, returnedValue);
+        }
+
+        [Fact]
+        public void GivenOtherReturnTypeThanPropertyType_GetPropertyGroupPropertyValue_ReturnsPropertyValue()
+        {
+            TestPageTypeWithPropertyGroups typedPageData = new TestPageTypeWithPropertyGroups();
+            typedPageData = new TypedPageActivator().CreateAndPopulateTypedInstance(typedPageData, typeof(TestPageTypeWithPropertyGroups)) as TestPageTypeWithPropertyGroups;
+            string propertyName = typedPageData.ImageOne.GetPropertyGroupPropertyName(propertyGroup => propertyGroup.NullableTestIntProperty);
+            int? propertyValue = 1;
+            typedPageData.Property.Add(propertyName, new PropertyNumber(propertyValue.Value));
+
+            int returnedValue = typedPageData.ImageOne.GetPropertyGroupPropertyValue<Image, int>(propertyGroup => propertyGroup.NullableTestIntProperty);
+
+            Assert.Equal<int>(propertyValue.Value, returnedValue);
+        }
+
+        [Fact]
+        public void GivenOtherReturnTypeThanPropertyTypeAndValueExistsAndIncludeDynamicIsFalse_GetPropertyGroupPropertyValue_ReturnsPropertyValue1()
+        {
+            TestPageTypeWithPropertyGroups typedPageData = new TestPageTypeWithPropertyGroups();
+            typedPageData = new TypedPageActivator().CreateAndPopulateTypedInstance(typedPageData, typeof(TestPageTypeWithPropertyGroups)) as TestPageTypeWithPropertyGroups;
+            string propertyName = typedPageData.ImageOne.GetPropertyGroupPropertyName(propertyGroup => propertyGroup.NullableTestIntProperty);
+
+            int? propertyValue = 1;
+            typedPageData.Property.Add(propertyName, new PropertyNumber(propertyValue.Value));
+
+
+            int returnedValue = typedPageData.ImageOne.GetPropertyGroupPropertyValue<Image, int?>(propertyGroup => propertyGroup.NullableTestIntProperty, false).Value;
+
+            Assert.Equal<int>(propertyValue.Value, returnedValue);
+        }
+
+        [Fact]
+        public void GivenOtherReturnTypeThanPropertyTypeAndValueExistsAndIncludeDynamicIsTrue_GetPropertyGroupPropertyValue_ReturnsPropertyValue1()
+        {
+            TestPageTypeWithPropertyGroups typedPageData = new TestPageTypeWithPropertyGroups();
+            typedPageData = new TypedPageActivator().CreateAndPopulateTypedInstance(typedPageData, typeof(TestPageTypeWithPropertyGroups)) as TestPageTypeWithPropertyGroups;
+            string propertyName = typedPageData.ImageOne.GetPropertyGroupPropertyName(propertyGroup => propertyGroup.NullableTestIntProperty);
+            int? propertyValue = 1;
+            typedPageData.Property.Add(propertyName, new PropertyNumber(propertyValue.Value));
+
+
+            int returnedValue = typedPageData.ImageOne.GetPropertyGroupPropertyValue<Image, int>(propertyGroup => propertyGroup.NullableTestIntProperty, true);
+
+            Assert.Equal<int>(propertyValue.Value, returnedValue);
+        }
+
+        [Fact]
+        public void GivenPropertyValueIsValueType_GetPropertyGroupPropertyValue_ReturnsPropertyValue()
+        {
+            TestPageTypeWithPropertyGroups typedPageData = new TestPageTypeWithPropertyGroups();
+            typedPageData = new TypedPageActivator().CreateAndPopulateTypedInstance(typedPageData, typeof(TestPageTypeWithPropertyGroups)) as TestPageTypeWithPropertyGroups;
+            string propertyName = typedPageData.ImageOne.GetPropertyGroupPropertyName(propertyGroup => propertyGroup.IntTestProperty);
+            int propertyValue = 1;
+            typedPageData.Property.Add(propertyName, new PropertyNumber(propertyValue));
+
+            int returnedValue = typedPageData.ImageOne.GetPropertyGroupPropertyValue(propertyGroup => propertyGroup.IntTestProperty);
+
+            Assert.Equal<int>(propertyValue, returnedValue);
+        }
+
+        [Fact]
+        public void GivenExpressionThatIsNotUnaryOrMember_GetPropertyGroupPropertyValue_ThrowsException()
+        {
+            TestPageTypeWithPropertyGroups typedPageData = new TestPageTypeWithPropertyGroups();
+            typedPageData = new TypedPageActivator().CreateAndPopulateTypedInstance(typedPageData, typeof(TestPageTypeWithPropertyGroups)) as TestPageTypeWithPropertyGroups;
+
+            Exception exception = Record.Exception(() => typedPageData.ImageOne.GetPropertyGroupPropertyValue(propertyGroup => propertyGroup.IntTestProperty + 1));
+
+            Assert.NotNull(exception);
+        }
+
+        [Fact]
+        public void GivenValueOfValueType_SetPropertyGroupPropertyValue_SetsPropertyValue()
+        {
+            TestPageTypeWithPropertyGroups typedPageData = new TestPageTypeWithPropertyGroups();
+            typedPageData = new TypedPageActivator().CreateAndPopulateTypedInstance(typedPageData, typeof(TestPageTypeWithPropertyGroups)) as TestPageTypeWithPropertyGroups;
+            string propertyName = typedPageData.ImageOne.GetPropertyGroupPropertyName(propertyGroup => propertyGroup.IntTestProperty);
+
+            typedPageData.Property.Add(propertyName, new PropertyNumber());
+            int valueToSet = 1;
+
+            typedPageData.ImageOne.SetPropertyGroupPropertyValue(propertyGroup => propertyGroup.IntTestProperty, valueToSet);
+
+            Assert.Equal<int>(valueToSet, (int)typedPageData[propertyName]);
+        }
+
+        [Fact]
+        public void GivenExpressionThatIsNotUnaryOrMember_SetPropertyGroupPropertyValue_ThrowsException()
+        {
+            TestPageTypeWithPropertyGroups typedPageData = new TestPageTypeWithPropertyGroups();
+            typedPageData = new TypedPageActivator().CreateAndPopulateTypedInstance(typedPageData, typeof(TestPageTypeWithPropertyGroups)) as TestPageTypeWithPropertyGroups;
+
+            Exception exception = Record.Exception(() => typedPageData.ImageOne.SetPropertyGroupPropertyValue(propertyGroup => propertyGroup.IntTestProperty + 1, 1));
+
+            Assert.NotNull(exception);
+        }
+
+        [Fact]
+        public void GivenExpressionWithProperty_GetPropertyGroupPropertyName_ReturnsThePropertysName()
+        {
+            TestPageTypeWithPropertyGroups typedPageData = new TestPageTypeWithPropertyGroups();
+            typedPageData = new TypedPageActivator().CreateAndPopulateTypedInstance(typedPageData, typeof(TestPageTypeWithPropertyGroups)) as TestPageTypeWithPropertyGroups;
+            string propertyName = typedPageData.ImageOne.GetPropertyGroupPropertyName(propertyGroup => propertyGroup.IntTestProperty);
+
+            string returnedValue = typedPageData.ImageOne.GetPropertyGroupPropertyName(propertyGroup => propertyGroup.IntTestProperty);
+
+            Assert.Equal<string>(propertyName, returnedValue);
+        }
+    }
+}

--- a/PageTypeBuilder.Tests/TestPageTypeWithPropertyGroups.cs
+++ b/PageTypeBuilder.Tests/TestPageTypeWithPropertyGroups.cs
@@ -23,6 +23,16 @@
 
         [PageTypeProperty(EditCaption = "Alt text", SortOrder = 10)]
         public virtual string AltText { get; set; }
+
+        [PageTypeProperty(EditCaption = "Nullable test int property", SortOrder = 20)]
+        public virtual int? NullableTestIntProperty { get; set; }
+
+        [PageTypeProperty(EditCaption = "int test property", SortOrder = 30)]
+        public virtual int IntTestProperty { get; set; }
+
+        [PageTypeProperty(EditCaption = "string test property", SortOrder = 40)]
+        public string StringTestProperty { get; set; }
+        
     }
 
 }

--- a/PageTypeBuilder/PageTypeBuilder.csproj
+++ b/PageTypeBuilder/PageTypeBuilder.csproj
@@ -142,6 +142,7 @@
     <Compile Include="PageTypeBuilderException.cs" />
     <Compile Include="PageTypePropertyGroup.cs" />
     <Compile Include="PageTypePropertyGroupAttribute.cs" />
+    <Compile Include="PageTypePropertyGroupExtensions.cs" />
     <Compile Include="PageTypePropertyGroupHierarchy.cs" />
     <Compile Include="Reflection\AppDomainAssemblyLocator.cs" />
     <Compile Include="Reflection\AssemblyExtensions.cs" />

--- a/PageTypeBuilder/PageTypePropertyGroup.cs
+++ b/PageTypeBuilder/PageTypePropertyGroup.cs
@@ -2,7 +2,7 @@
 {
     public abstract class PageTypePropertyGroup
     {
-        internal TypedPageData TypedPageData { get; set; }
+        public TypedPageData TypedPageData { get; internal set; }
         internal PageTypePropertyGroupHierarchy Hierarchy { get; set; }
 
         internal void PopuplateInstance(TypedPageData destination, string hierarchy)

--- a/PageTypeBuilder/PageTypePropertyGroupExtensions.cs
+++ b/PageTypeBuilder/PageTypePropertyGroupExtensions.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Linq.Expressions;
+using EPiServer.Core;
+using PageTypeBuilder.Reflection;
+
+namespace PageTypeBuilder
+{
+    public static class PageTypePropertyGroupExtensionMethods
+    {
+        public static TProperty GetPropertyGroupPropertyValue<TPageTypePropertyGroup, TProperty>(this TPageTypePropertyGroup propertyGroup, Expression<Func<TPageTypePropertyGroup, TProperty>> expression)
+            where TPageTypePropertyGroup : PageTypePropertyGroup
+        {
+            return propertyGroup.GetPropertyGroupPropertyValue(expression, true);
+        }
+
+        public static TProperty GetPropertyGroupPropertyValue<TPageTypePropertyGroup, TProperty>(this TPageTypePropertyGroup propertyGroup, Expression<Func<TPageTypePropertyGroup, TProperty>> expression,
+            bool usePropertyGetHandler) where TPageTypePropertyGroup : PageTypePropertyGroup
+        {
+            MemberExpression memberExpression = GetMemberExpression(expression);
+            string propertyName = PageTypePropertyGroupHierarchy.ResolvePropertyName(propertyGroup.Hierarchy.Value, memberExpression.Member.Name);
+
+            object value;
+            if (usePropertyGetHandler)
+                value = propertyGroup.TypedPageData[propertyName];
+            else
+                value = propertyGroup.TypedPageData.GetValue(propertyName);
+
+            return ConvertToRequestedType<TProperty>(value);
+        }
+
+        private static MemberExpression GetMemberExpression<TPageTypePropertyGroup, TProperty>(Expression<Func<TPageTypePropertyGroup, TProperty>> expression)
+        {
+            MemberExpression memberExpression = null;
+
+            if (expression.Body is MemberExpression)
+            {
+                memberExpression = (MemberExpression)expression.Body;
+            }
+            else if (expression.Body is UnaryExpression)
+            {
+                UnaryExpression unaryExpression = (UnaryExpression)expression.Body;
+                memberExpression = unaryExpression.Operand as MemberExpression;
+            }
+
+            if (memberExpression == null)
+                throw new PageTypeBuilderException("The body of the expression must be either a MemberExpression of a UnaryExpression.");
+
+            return memberExpression;
+        }
+
+        private static TProperty ConvertToRequestedType<TProperty>(object value)
+        {
+            if (value != null)
+                return (TProperty)value;
+
+            if (typeof(TProperty) == typeof(bool))
+                return default(TProperty);
+
+            if (!typeof(TProperty).CanBeNull())
+                throw new PageTypeBuilderException(@"The property value is null and the requested type is a value type. 
+                    Consider using nullable as type or make the property mandatory.");
+
+            return (TProperty)value;
+        }
+
+        public static PropertyData GetPropertyGroupProperty<TPageTypePropertyGroup>(this TPageTypePropertyGroup propertyGroup, Expression<Func<TPageTypePropertyGroup, object>> expression)
+            where TPageTypePropertyGroup : PageTypePropertyGroup
+        {
+            return GetPropertyGroupProperty<TPageTypePropertyGroup, PropertyData>(propertyGroup, expression);
+        }
+
+        public static TPropertyData GetPropertyGroupProperty<TPageTypePropertyGroup, TPropertyData>(this TPageTypePropertyGroup propertyGroup, Expression<Func<TPageTypePropertyGroup, object>> expression)
+            where TPageTypePropertyGroup : PageTypePropertyGroup
+            where TPropertyData : PropertyData
+        {
+            MemberExpression memberExpression = GetMemberExpression(expression);
+            string propertyName = PageTypePropertyGroupHierarchy.ResolvePropertyName(propertyGroup.Hierarchy.Value, memberExpression.Member.Name);
+            PropertyData propertyData = propertyGroup.TypedPageData.Property[propertyName];
+            return (TPropertyData)propertyData;
+        }
+
+        public static TProperty GetPropertyGroupPropertyValue<TPageTypePropertyGroup, TProperty>(this TPageTypePropertyGroup propertyGroup, Expression<Func<TPageTypePropertyGroup, object>> expression)
+            where TPageTypePropertyGroup : PageTypePropertyGroup
+        {
+            return (TProperty)propertyGroup.GetPropertyGroupPropertyValue(expression, false);
+        }
+
+        public static TProperty GetPropertyGroupPropertyValue<TPageTypePropertyGroup, TProperty>(this TPageTypePropertyGroup propertyGroup, Expression<Func<TPageTypePropertyGroup, object>> expression,
+            bool usePropertyGetHandler) where TPageTypePropertyGroup : PageTypePropertyGroup
+        {
+            MemberExpression memberExpression = GetMemberExpression(expression);
+            string propertyName = PageTypePropertyGroupHierarchy.ResolvePropertyName(propertyGroup.Hierarchy.Value, memberExpression.Member.Name);
+
+            object value;
+            if (usePropertyGetHandler)
+                value = (TProperty)propertyGroup.TypedPageData[propertyName];
+            else
+                value = propertyGroup.TypedPageData.GetValue(propertyName);
+
+            return ConvertToRequestedType<TProperty>(value);
+        }
+
+        public static void SetPropertyGroupPropertyValue<TPageTypePropertyGroup>(this TPageTypePropertyGroup propertyGroup, Expression<Func<TPageTypePropertyGroup, object>> expression, object value) 
+            where TPageTypePropertyGroup : PageTypePropertyGroup
+        {
+            string propertyName = GetPropertyGroupPropertyName(propertyGroup, expression);
+            propertyGroup.TypedPageData[propertyName] = value;
+        }
+
+        public static string GetPropertyGroupPropertyName<TPageTypePropertyGroup>(this TPageTypePropertyGroup propertyGroup, Expression<Func<TPageTypePropertyGroup, object>> expression)
+            where TPageTypePropertyGroup : PageTypePropertyGroup
+        {
+            return PageTypePropertyGroupHierarchy.ResolvePropertyName(propertyGroup.Hierarchy.Value, GetMemberExpression(expression).Member.Name);
+        }
+    }
+}


### PR DESCRIPTION
PropertyGroup amends - TypedPageData is now public and internally settable.
There are now new extension methods for PropertyGroups to get properties, property values and set them
