### PR TITLE
Non-public property support for property settings synchronization (2nd try)

### DIFF
--- a/PageTypeBuilder/Synchronization/PageDefinitionSynchronization/PageDefinitionSpecificPropertySettingsUpdater.cs
+++ b/PageTypeBuilder/Synchronization/PageDefinitionSynchronization/PageDefinitionSpecificPropertySettingsUpdater.cs
@@ -142,12 +142,12 @@ namespace PageTypeBuilder.Synchronization.PageDefinitionSynchronization
             
             PropertyInfo prop = null;
 
-            if (propertyDefinition.Name.Contains("-"))
+            int propertyGroupDashIndex = propertyDefinition.Name.IndexOf("-", StringComparison.Ordinal);
+            if (propertyGroupDashIndex >= 0)
             {
                 // the property definition is a property belonging to a property group
-                int index = propertyDefinition.Name.IndexOf("-");
-                string propertyGroupPropertyName = propertyDefinition.Name.Substring(0, index);
-                string propertyName = propertyDefinition.Name.Substring(index + 1);
+                string propertyGroupPropertyName = propertyDefinition.Name.Substring(0, propertyGroupDashIndex);
+                string propertyName = propertyDefinition.Name.Substring(propertyGroupDashIndex + 1);
 
                 PropertyInfo propertyGroupProperty = pageTypeDefinition.Type.GetProperties(propertyBindingFlags).FirstOrDefault(p => String.Equals(p.Name, propertyGroupPropertyName));
                 //if (propertyGroupProperty == null)

--- a/PageTypeBuilder/Synchronization/PageDefinitionSynchronization/PageDefinitionSpecificPropertySettingsUpdater.cs
+++ b/PageTypeBuilder/Synchronization/PageDefinitionSynchronization/PageDefinitionSpecificPropertySettingsUpdater.cs
@@ -78,10 +78,9 @@ namespace PageTypeBuilder.Synchronization.PageDefinitionSynchronization
             {
                 var container = GetPropertySettingsContainer(pageDefinition);
                 //TODO: Should validate not null and valid type at startup
-                var globalSettingsUpdater = globalPropertySettingsLocator.GetGlobalPropertySettingsUpdaters().Where(u => u.WrappedInstanceType == useGlobalSettingsAttribute.Type).First();
+                var globalSettingsUpdater = globalPropertySettingsLocator.GetGlobalPropertySettingsUpdaters().First(u => u.WrappedInstanceType == useGlobalSettingsAttribute.Type);
                 var wrapper = _propertySettingsRepositoryMethod().GetGlobals(globalSettingsUpdater.SettingsType)
-                    .Where(w => globalSettingsUpdater.Match(w))
-                    .First();
+                    .First(w => globalSettingsUpdater.Match(w));
                 PropertySettingsWrapper existingWrapper = container.Settings.ContainsKey(globalSettingsUpdater.SettingsType.FullName)
                     ? container.Settings[globalSettingsUpdater.SettingsType.FullName]
                     : null;
@@ -150,7 +149,7 @@ namespace PageTypeBuilder.Synchronization.PageDefinitionSynchronization
                 string propertyGroupPropertyName = propertyDefinition.Name.Substring(0, index);
                 string propertyName = propertyDefinition.Name.Substring(index + 1);
 
-                PropertyInfo propertyGroupProperty = pageTypeDefinition.Type.GetProperties(propertyBindingFlags).Where(p => String.Equals(p.Name, propertyGroupPropertyName)).FirstOrDefault();
+                PropertyInfo propertyGroupProperty = pageTypeDefinition.Type.GetProperties(propertyBindingFlags).FirstOrDefault(p => String.Equals(p.Name, propertyGroupPropertyName));
                 //if (propertyGroupProperty == null)
                 //{
                 //    // TODO: Enable exceptions for a development fail-fast mode?
@@ -160,14 +159,13 @@ namespace PageTypeBuilder.Synchronization.PageDefinitionSynchronization
                 //}
                 if (propertyGroupProperty != null)
                 {
-                    prop = propertyGroupProperty.PropertyType.GetProperties().Where(p => String.Equals(p.Name, propertyName)).FirstOrDefault();
+                    prop = propertyGroupProperty.PropertyType.GetProperties().FirstOrDefault(p => String.Equals(p.Name, propertyName));
                 }
             }
             else
             {
                 prop =
-                    pageTypeDefinition.Type.GetProperties(propertyBindingFlags).Where(p => String.Equals(p.Name, propertyDefinition.Name)).
-                        FirstOrDefault();
+                    pageTypeDefinition.Type.GetProperties(propertyBindingFlags).FirstOrDefault(p => String.Equals(p.Name, propertyDefinition.Name));
             }
 
             if (prop == null)


### PR DESCRIPTION
This is an updated pull-request (in a new branch) for enabling property settings synchronization to work with non-public page properties, e.g., a protected property only used by the infrastructure in a base class (my use case). While it does support non-public properties now, the settings updater would still not crash in case it cannot find a property for some other reason. No exceptions are thrown, instead favoring to continue silently. I did however leave some commented code for throwing an exception, just in case a fail-fast developer mode should be introduced (just delete it if it’s not on the roadmap).

Instead of unit tests, the specifications were updated to verify and catch the non-public case as well. I tried to avoid code duplication by reusing the same behaviors for both the public and non-public cases.

I also made small improvements to the code in general, but put each of those in separate commits. It should be easy to review each commit, and should you disagree with any of them, just cherry-pick the ones you like.

Please tell me if I need to improve something. All tests and specs pass, of course.
