### PR TITLE
Support for disabling page type synchronization through a file

### DIFF
--- a/PageTypeBuilder.Tests/Configuration/PageTypeBuilderConfigurationTests.cs
+++ b/PageTypeBuilder.Tests/Configuration/PageTypeBuilderConfigurationTests.cs
@@ -1,24 +1,154 @@
-﻿using PageTypeBuilder.Configuration;
+﻿using System;
+using System.Configuration;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using PageTypeBuilder.Configuration;
 using Xunit;
 
 namespace PageTypeBuilder.Tests.Configuration
 {
     public class PageTypeBuilderConfigurationTests
     {
+        private readonly string assemblyConfigFile =AppDomain.CurrentDomain.SetupInformation.ConfigurationFile;
+        private readonly string disableSyncFile =
+            Path.Combine(Path.GetDirectoryName(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile), "DisablePageTypeSync.config");
+        
         [Fact]
         public void DisablePageTypeUpdation_DefaultsToFalse()
         {
-            PageTypeBuilderConfiguration configuration = new PageTypeBuilderConfiguration();
+            var configuration = new PageTypeBuilderConfiguration();
             
-            Assert.Equal<bool>(false, configuration.DisablePageTypeUpdation);
+            Assert.Equal(false, configuration.DisablePageTypeUpdation);
         }
 
         [Fact]
         public void GivenPageTypeUpdationDisabledInAppConfig_DisablePageTypeUpdation_ReturnsTrue()
         {
+            RecreateConfigSectionWithSingleAttribute("disablePageTypeUpdation", "true");
+
             PageTypeBuilderConfiguration configuration = PageTypeBuilderConfiguration.GetConfiguration();
 
-            Assert.Equal<bool>(true, configuration.DisablePageTypeUpdation);
+            Assert.Equal(true, configuration.DisablePageTypeUpdation);
+        }
+
+        [Fact]
+        public void GivenPageTypeUpdationFalseInAppConfig_DisablePageTypeUpdation_ReturnsFalse()
+        {
+            RecreateConfigSectionWithSingleAttribute("disablePageTypeUpdation", "false");
+
+            PageTypeBuilderConfiguration configuration = PageTypeBuilderConfiguration.GetConfiguration();
+
+            Assert.Equal(false, configuration.DisablePageTypeUpdation);
+        }
+
+        [Fact]
+        public void GivenPageTypeSyncFalseInAppConfig_DisablePageTypeUpdation_ReturnsFalse()
+        {
+            RecreateConfigSectionWithSingleAttribute("disablePageTypeSync", "false");
+
+            PageTypeBuilderConfiguration configuration = PageTypeBuilderConfiguration.GetConfiguration();
+
+            Assert.Equal(false, configuration.DisablePageTypeUpdation);
+        }
+
+        [Fact]
+        public void GivenOnlyPageTypeSyncDisabledInAppConfig_DisablePageTypeUpdation_ReturnsTrue()
+        {
+            RecreateConfigSectionWithSingleAttribute("disablePageTypeSync", "true");
+
+            PageTypeBuilderConfiguration configuration = PageTypeBuilderConfiguration.GetConfiguration();
+
+            Assert.Equal(true, configuration.DisablePageTypeUpdation);
+        }
+
+        [Fact]
+        public void GivenOnlyPageTypeUpdationFileEmptyInAppConfig_DisablePageTypeUpdation_ReturnsFalse()
+        {
+            RecreateConfigSectionWithSingleAttribute("disablePageTypeUpdationFile", "");
+
+            PageTypeBuilderConfiguration configuration = PageTypeBuilderConfiguration.GetConfiguration();
+
+            Assert.Equal(false, configuration.DisablePageTypeUpdation);
+        }
+
+        [Fact]
+        public void GivenOnlyPageTypeSyncFileEmptyInAppConfig_DisablePageTypeUpdation_ReturnsFalse()
+        {
+            RecreateConfigSectionWithSingleAttribute("disablePageTypeSyncFile", "");
+
+            PageTypeBuilderConfiguration configuration = PageTypeBuilderConfiguration.GetConfiguration();
+
+            Assert.Equal(false, configuration.DisablePageTypeUpdation);
+        }
+
+        [Fact]
+        public void GivenOnlyPageTypeUpdationFileWithNonExistingFileInAppConfig_DisablePageTypeUpdation_ReturnsFalse()
+        {
+            RecreateConfigSectionWithSingleAttribute("disablePageTypeUpdationFile", disableSyncFile);
+            RemoveSyncDisablingFile();
+
+            PageTypeBuilderConfiguration configuration = PageTypeBuilderConfiguration.GetConfiguration();
+
+            Assert.Equal(false, configuration.DisablePageTypeUpdation);
+        }
+
+        [Fact]
+        public void GivenOnlyPageTypeSyncFileWithNonExistingFileInAppConfig_DisablePageTypeUpdation_ReturnsFalse()
+        {
+            RecreateConfigSectionWithSingleAttribute("disablePageTypeSyncFile", disableSyncFile);
+            RemoveSyncDisablingFile();
+
+            PageTypeBuilderConfiguration configuration = PageTypeBuilderConfiguration.GetConfiguration();
+
+            Assert.Equal(false, configuration.DisablePageTypeUpdation);
+        }
+        
+        [Fact]
+        public void GivenOnlyPageTypeUpdationFileWithExistingFileInAppConfig_DisablePageTypeUpdation_ReturnsTrue()
+        {
+            RecreateConfigSectionWithSingleAttribute("disablePageTypeUpdationFile", disableSyncFile);
+            CreateSyncDisablingFile();
+
+            PageTypeBuilderConfiguration configuration = PageTypeBuilderConfiguration.GetConfiguration();
+
+            Assert.Equal(true, configuration.DisablePageTypeUpdation);
+        }
+
+        [Fact]
+        public void GivenOnlyPageTypeSyncFileWithExistingFileInAppConfig_DisablePageTypeUpdation_ReturnsTrue()
+        {
+            RecreateConfigSectionWithSingleAttribute("disablePageTypeSyncFile", disableSyncFile);
+            CreateSyncDisablingFile();
+
+            PageTypeBuilderConfiguration configuration = PageTypeBuilderConfiguration.GetConfiguration();
+
+            Assert.Equal(true, configuration.DisablePageTypeUpdation);
+        }
+
+        private void RecreateConfigSectionWithSingleAttribute(string attributeName, string attributeValue)
+        {
+            var doc = XDocument.Load(assemblyConfigFile, LoadOptions.PreserveWhitespace);
+            var ptb = doc.Descendants("pageTypeBuilder").First();
+
+            ptb.Attributes().Remove();
+            ptb.SetAttributeValue(attributeName, attributeValue);
+
+            doc.Save(assemblyConfigFile);
+            ConfigurationManager.RefreshSection("pageTypeBuilder");
+        }
+
+        private void CreateSyncDisablingFile()
+        {
+            if (!File.Exists(disableSyncFile))
+            {
+                File.WriteAllText(disableSyncFile, "");
+            }
+        }
+
+        private void RemoveSyncDisablingFile()
+        {
+            File.Delete(disableSyncFile);
         }
     }
 }

--- a/PageTypeBuilder/Configuration/PageTypeBuilderConfiguration.cs
+++ b/PageTypeBuilder/Configuration/PageTypeBuilderConfiguration.cs
@@ -1,35 +1,84 @@
 ﻿using System.Configuration;
+using System.Web;
 
 namespace PageTypeBuilder.Configuration
 {
-    public class PageTypeBuilderConfiguration : ConfigurationSection
-    {
-        public static PageTypeBuilderConfiguration GetConfiguration()
-        {
-            PageTypeBuilderConfiguration configuration = ConfigurationManager.GetSection("pageTypeBuilder") as PageTypeBuilderConfiguration;
+	public class PageTypeBuilderConfiguration : ConfigurationSection
+	{
+		/// <summary>
+		/// The original option for disabling page type synchronization.
+		/// </summary>
+		private static readonly ConfigurationProperty disablePageTypeUpdation =
+			new ConfigurationProperty("disablePageTypeUpdation", typeof(bool), false);
 
-            if (configuration != null)
-                return configuration;
+		/// <summary>
+		/// A synonym of disablePageTypeUpdation.
+		/// </summary>
+		private static readonly ConfigurationProperty disablePageTypeSync =
+			new ConfigurationProperty("disablePageTypeSync", typeof(bool), false);
 
-            return new PageTypeBuilderConfiguration();
-        }
+		/// <summary>
+		/// Used to set the path to a configuration file which, when it exists, will
+		/// disable page type synchronization. It's useful for disabling sync in
+		/// a multi-site EPiServer Enterprise installation, after the first site
+		/// has been started.
+		/// </summary>
+		private static readonly ConfigurationProperty disablePageTypeUpdationFile =
+			new ConfigurationProperty("disablePageTypeUpdationFile", typeof(string), "");
 
-        [ConfigurationProperty("disablePageTypeUpdation", IsRequired = false)]
-        public virtual bool DisablePageTypeUpdation
-        {
-            get
-            {
-                return (bool)this["disablePageTypeUpdation"];
-            }
-        }
+		/// <summary>
+		/// A synonym of disablePageTypeUpdationFile.
+		/// </summary>
+		private static readonly ConfigurationProperty disablePageTypeSyncFile =
+			new ConfigurationProperty("disablePageTypeSyncFile", typeof(string), "");
 
-        [ConfigurationProperty("xmlns", IsRequired = false)]
-        public string XmlNamespace
-        {
-            get
-            {
-                return "http://PageTypeBuilder.Configuration.PageTypeBuilderConfiguration";
-            }
-        }
-    }
+		private static readonly ConfigurationPropertyCollection properties =
+			new ConfigurationPropertyCollection
+		    {
+				new ConfigurationProperty("xmlns", typeof(string), "http://PageTypeBuilder.Configuration.PageTypeBuilderConfiguration"),
+		        disablePageTypeUpdation,
+				disablePageTypeSync,
+				disablePageTypeUpdationFile,
+				disablePageTypeSyncFile
+		    };
+
+		protected override ConfigurationPropertyCollection Properties
+		{
+			get { return properties; }
+		}
+
+		public static PageTypeBuilderConfiguration GetConfiguration()
+		{
+			var configuration = ConfigurationManager.GetSection("pageTypeBuilder") as PageTypeBuilderConfiguration;
+			return configuration ?? new PageTypeBuilderConfiguration();
+		}
+
+		public virtual bool DisablePageTypeUpdation
+		{
+			get
+			{
+				return (bool)this["disablePageTypeUpdation"]
+					|| (bool)this["disablePageTypeSync"]
+					|| IsDisabledByFile("disablePageTypeUpdationFile")
+					|| IsDisabledByFile("disablePageTypeSyncFile");
+			}
+		}
+
+		private bool IsDisabledByFile(string configFileKey)
+		{
+			var configFile = (string)this[configFileKey];
+			if (string.IsNullOrEmpty(configFile))
+			{
+				return false;
+			}
+
+			var ctx = HttpContext.Current;
+			if (ctx != null)
+			{
+				configFile = ctx.Server.MapPath(configFile);
+			}
+
+			return System.IO.File.Exists(configFile);
+		}
+	}
 }


### PR DESCRIPTION
I've added support for disabling page type synchronization through the existence of a file. The file is configured through a new attribute in PTB's configuration section: disablePageTypeUpdationFile.

It's useful in e.g. an EPiServer Enterprise scenario, where multiple sites share the same code and database. Only the first web site needs to synchronize page types, and once that's been done, the deploy script can create a file to prevent further synchronization.

One could of course have achieved the same thing by using configSource to put the Page Type Builder configuration section in a separate file, and then change the original attribute (a separate file is important for not restarting the already started first site, like you would by changing web.config). I just felt this alternative method was better because:
- source-control versioned files needn't be changed, and
- it was a little bit easier to implement in our deployment scripts.

While I was at it, I also introduced disablePageTypeSync and disablePageTypeSyncFile as _synonyms_ of the Updation attributes, since I can't seem to remember "Updation" whenever I need it.

I added to already existing unit tests, instead of writing new specs. IMHO, low-level stuff like this is better expressed using unit tests anyway. It’s also _fully backward compatible_.
