### PR TITLE
New PageTypePropertyGroupPropertyOverride attribute

### DIFF
--- a/PageTypeBuilder.Specs/Synchronization/PageTypeSynchronization/PropertySynchronization/PropertyGroupPropertiesSynchronization.cs
+++ b/PageTypeBuilder.Specs/Synchronization/PageTypeSynchronization/PropertySynchronization/PropertyGroupPropertiesSynchronization.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using EPiServer.DataAbstraction;
 using EPiServer.Security;
+using PageTypeBuilder;
 using PageTypeBuilder.Specs.Helpers.TypeBuildingDsl;
 using Machine.Specifications;
 
@@ -17,10 +18,10 @@ namespace PageTypeBuilder.Specs.Synchronization.PageTypeSynchronization.Property
         Establish context = () =>
         {
             var propertyGroupAttribute = new PageTypePropertyGroupAttribute
-                                             {
-                                                 EditCaptionPrefix = "Property One - ",
-                                                 StartSortOrderFrom = 100
-                                             };
+            {
+                EditCaptionPrefix = "Property One - ",
+                StartSortOrderFrom = 100
+            };
 
             SyncContext.CreateAndAddPageTypeClassToAppDomain(type =>
             {
@@ -72,9 +73,9 @@ namespace PageTypeBuilder.Specs.Synchronization.PageTypeSynchronization.Property
                 SyncContext.PageDefinitionRepository.List().FirstOrDefault(p => string.Equals(p.Name, "PropertyOne-AltText")).Tab.ID.ShouldEqual(-1);
     }
 
+    [Subject("Synchronization")]
     public class when_a_page_type_property_is_annotated_with_property_group_with_tab_defined : SynchronizationSpecs
     {
-
         static string propertyName = "PropertyOne";
         static string pageTypeName = "PageTypeName";
 
@@ -97,7 +98,7 @@ namespace PageTypeBuilder.Specs.Synchronization.PageTypeSynchronization.Property
                     prop.AddAttributeTemplate(propertyGroupAttribute);
                 });
             });
-            
+
             SyncContext.AssemblyLocator.Add(typeof(when_a_page_type_property_is_annotated_with_property_group).Assembly);
         };
 
@@ -111,6 +112,86 @@ namespace PageTypeBuilder.Specs.Synchronization.PageTypeSynchronization.Property
         It should_have_a_property_one_image_alt_page_type_property_with_the_correct_tab =
             () =>
                 SyncContext.PageDefinitionRepository.List().FirstOrDefault(p => string.Equals(p.Name, "PropertyOne-AltText")).Tab.ID.ShouldEqual(SyncContext.TabDefinitionRepository.List().Where(current => !string.IsNullOrEmpty(current.Name) && current.Name.Equals("Footer")).First().ID);
+    }
+
+    [Subject("Synchronization")]
+    public class when_a_page_type_property_is_annotated_with_property_group_with_property_attribute_values_overridden : SynchronizationSpecs
+    {
+        static string propertyName = "PropertyOne";
+        static string pageTypeName = "PageTypeName";
+
+        Establish context = () =>
+        {
+            var propertyGroupAttribute = new PageTypePropertyGroupAttribute
+            {
+                EditCaptionPrefix = "Property One - ",
+                StartSortOrderFrom = 100,
+                Tab = typeof(FooterTab)
+            };
+
+            var pageTypePropertyOverrideAttribute = new PageTypePropertyGroupPropertyOverrideAttribute
+            {
+                PropertyName = "ImageUrl",
+                EditCaption = "New Caption",
+                DefaultValue = "NewDefaultValue",
+                DefaultValueType = DefaultValueType.Value,
+                DisplayInEditMode = false,
+                HelpText = "NewHelpText",
+                Required = true,
+                Searchable = true,
+                UniqueValuePerLanguage = true
+            };
+
+            SyncContext.CreateAndAddPageTypeClassToAppDomain(type =>
+            {
+                type.Name = pageTypeName;
+                type.AddProperty(prop =>
+                {
+                    prop.Name = propertyName;
+                    prop.Type = typeof(Image);
+                    prop.AddAttributeTemplate(propertyGroupAttribute);
+                    prop.AddAttributeTemplate(pageTypePropertyOverrideAttribute);
+                });
+            });
+
+            SyncContext.AssemblyLocator.Add(typeof(when_a_page_type_property_is_annotated_with_property_group_with_property_attribute_values_overridden).Assembly);
+
+        };
+
+        Because of =
+            () => SyncContext.PageTypeSynchronizer.SynchronizePageTypes();
+
+        It should_have_a_property_one_image_url_page_type_property_with_an_updated_edit_caption =
+            () =>
+                SyncContext.PageDefinitionRepository.List().FirstOrDefault(p => string.Equals(p.Name, "PropertyOne-ImageUrl")).EditCaption.ShouldEqual("Property One - New Caption");
+
+        It should_have_a_property_one_image_url_page_type_property_with_an_updated_default_value =
+            () =>
+                SyncContext.PageDefinitionRepository.List().FirstOrDefault(p => string.Equals(p.Name, "PropertyOne-ImageUrl")).DefaultValue.ShouldEqual("NewDefaultValue");
+
+        It should_have_a_property_one_image_url_page_type_property_with_an_updated_default_value_type =
+            () =>
+                SyncContext.PageDefinitionRepository.List().FirstOrDefault(p => string.Equals(p.Name, "PropertyOne-ImageUrl")).DefaultValueType.ShouldEqual(DefaultValueType.Value);
+
+        It should_have_a_property_one_image_url_page_type_property_with_an_updated_display_edit_ui =
+            () =>
+                SyncContext.PageDefinitionRepository.List().FirstOrDefault(p => string.Equals(p.Name, "PropertyOne-ImageUrl")).DisplayEditUI.ShouldEqual(false);
+
+        It should_have_a_property_one_image_url_page_type_property_with_an_updated_help_text =
+            () =>
+                SyncContext.PageDefinitionRepository.List().FirstOrDefault(p => string.Equals(p.Name, "PropertyOne-ImageUrl")).HelpText.ShouldEqual("NewHelpText");
+
+        It should_have_a_property_one_image_url_page_type_property_with_an_updated_required =
+            () =>
+                SyncContext.PageDefinitionRepository.List().FirstOrDefault(p => string.Equals(p.Name, "PropertyOne-ImageUrl")).Required.ShouldEqual(true);
+
+        It should_have_a_property_one_image_url_page_type_property_with_an_updated_searchable =
+            () =>
+                SyncContext.PageDefinitionRepository.List().FirstOrDefault(p => string.Equals(p.Name, "PropertyOne-ImageUrl")).Searchable.ShouldEqual(true);
+
+        It should_have_a_property_one_image_url_page_type_property_with_an_updated_unique_value_per_language =
+            () =>
+                SyncContext.PageDefinitionRepository.List().FirstOrDefault(p => string.Equals(p.Name, "PropertyOne-ImageUrl")).LanguageSpecific.ShouldEqual(true);
     }
 
     public class Image : PageTypePropertyGroup
@@ -139,4 +220,5 @@ namespace PageTypeBuilder.Specs.Synchronization.PageTypeSynchronization.Property
             get { return 1000; }
         }
     }
+
 }

--- a/PageTypeBuilder.Specs/Synchronization/PageTypeSynchronization/PropertySynchronization/ValueSetting.cs
+++ b/PageTypeBuilder.Specs/Synchronization/PageTypeSynchronization/PropertySynchronization/ValueSetting.cs
@@ -168,6 +168,9 @@
             PropertyInfo property = pageTypeType.GetProperty(propertyName);
             propertyAttribute = property.GetCustomAttributes(typeof(PageTypePropertyAttribute), false).First() as PageTypePropertyAttribute;
 
+            propertyAttribute.DefaultValue = "true";
+            propertyAttribute.DefaultValueType = DefaultValueType.Value;
+
             var existingPageDefinition = new PageDefinition();
             existingPageDefinition.Type = SyncContext.PageDefinitionTypeRepository.GetPageDefinitionType<PropertyXhtmlString>();
             existingPageDefinition.PageTypeID = existingPageType.ID;
@@ -177,8 +180,10 @@
             existingPageDefinition.Tab = SyncContext.TabDefinitionRepository.GetTabDefinition(tabName);
             existingPageDefinition.Required = !propertyAttribute.Required;
             existingPageDefinition.Searchable = !propertyAttribute.Searchable;
-            existingPageDefinition.DefaultValue = "asdf";
-            existingPageDefinition.DefaultValueType = DefaultValueType.Inherit;
+
+            existingPageDefinition.DefaultValue = propertyAttribute.DefaultValue.ToString();
+            existingPageDefinition.DefaultValueType = propertyAttribute.DefaultValueType;
+
             existingPageDefinition.DisplayEditUI = !propertyAttribute.DisplayInEditMode;
             existingPageDefinition.FieldOrder = propertyAttribute.SortOrder + 100;
             existingPageDefinition.LanguageSpecific = !propertyAttribute.UniqueValuePerLanguage;

--- a/PageTypeBuilder.Tests/Discovery/PageTypePropertyDefinitionTests.cs
+++ b/PageTypeBuilder.Tests/Discovery/PageTypePropertyDefinitionTests.cs
@@ -16,8 +16,8 @@ namespace PageTypeBuilder.Tests.Discovery
             string name = TestValueUtility.CreateRandomString();
             Type propertyType = typeof(string);
             IPageType pageType = new NativePageType();
-            
-            PageTypePropertyDefinition definition = new PageTypePropertyDefinition(name, propertyType, pageType, attribute);
+
+            PageTypePropertyDefinition definition = new PageTypePropertyDefinition(name, propertyType, pageType, attribute, null);
 
 
             Assert.Equal<string>(name, definition.Name);
@@ -31,7 +31,7 @@ namespace PageTypeBuilder.Tests.Discovery
             Type propertyType = typeof(string);
             IPageType pageType = new NativePageType();
 
-            PageTypePropertyDefinition definition = new PageTypePropertyDefinition(name, propertyType, pageType, attribute);
+            PageTypePropertyDefinition definition = new PageTypePropertyDefinition(name, propertyType, pageType, attribute, null);
 
 
             Assert.Equal<Type>(propertyType, definition.PropertyType);
@@ -46,7 +46,7 @@ namespace PageTypeBuilder.Tests.Discovery
             IPageType pageType = new NativePageType();
             pageType.GUID = Guid.NewGuid();
 
-            PageTypePropertyDefinition definition = new PageTypePropertyDefinition(name, propertyType, pageType, attribute);
+            PageTypePropertyDefinition definition = new PageTypePropertyDefinition(name, propertyType, pageType, attribute, null);
 
 
             Assert.Equal<IPageType>(pageType, definition.PageType, new PageTypeComparer());
@@ -73,10 +73,10 @@ namespace PageTypeBuilder.Tests.Discovery
             Type propertyType = typeof(string);
             IPageType pageType = new NativePageType();
 
-            PageTypePropertyDefinition definition = new PageTypePropertyDefinition(name, propertyType, pageType, attribute);
+            PageTypePropertyDefinition definition = new PageTypePropertyDefinition(name, propertyType, pageType, attribute, null);
 
 
-            Assert.Equal<PageTypePropertyAttribute>(attribute, definition.PageTypePropertyAttribute, 
+            Assert.Equal<PageTypePropertyAttribute>(attribute, definition.PageTypePropertyAttribute,
                                                     new PageTypePropertyComparer());
         }
 

--- a/PageTypeBuilder.Tests/Synchronization/PageDefinitionSynchronizationEngineTests/PageDefinitionSynchronizationEngineTestsUtility.cs
+++ b/PageTypeBuilder.Tests/Synchronization/PageDefinitionSynchronizationEngineTests/PageDefinitionSynchronizationEngineTestsUtility.cs
@@ -12,7 +12,7 @@ namespace PageTypeBuilder.Tests.Synchronization.PageDefinitionSynchronizationEng
             Type type = typeof(string);
             IPageType pageType = new NativePageType();
             PageTypePropertyAttribute attribute = new PageTypePropertyAttribute();
-            return new PageTypePropertyDefinition(name, type, pageType, attribute);
+            return new PageTypePropertyDefinition(name, type, pageType, attribute, null);
         }
     }
 }

--- a/PageTypeBuilder.Tests/Synchronization/PageDefinitionSynchronizationEngineTests/UpdatePageDefinitionTests.cs
+++ b/PageTypeBuilder.Tests/Synchronization/PageDefinitionSynchronizationEngineTests/UpdatePageDefinitionTests.cs
@@ -162,7 +162,11 @@ namespace PageTypeBuilder.Tests.Synchronization.pageDefinitionUpdaterTests
             var pageDefinitionUpdater = GetPageDefinitionUpdater();
             PageDefinition pageDefinitionToUpdate = new PageDefinition();
             PageTypePropertyDefinition propertyDefinition = CreatePageTypePropertyDefinition();
-            propertyDefinition.PageTypePropertyAttribute.DefaultValue = TestValueUtility.CreateRandomString();
+            propertyDefinition.PageTypePropertyAttribute.DefaultValue = "true";// TestValueUtility.CreateRandomString();
+
+            // As we have had to modifiy how default value and value types are handled in definition update
+            // we now have to specify a default value to satisfy this test
+            propertyDefinition.PageTypePropertyAttribute.DefaultValueType = DefaultValueType.Value;
 
             pageDefinitionUpdater.UpdateExistingPageDefinition(pageDefinitionToUpdate, propertyDefinition);
 
@@ -179,6 +183,10 @@ namespace PageTypeBuilder.Tests.Synchronization.pageDefinitionUpdaterTests
             PageDefinition pageDefinitionToUpdate = new PageDefinition();
             PageTypePropertyDefinition propertyDefinition = CreatePageTypePropertyDefinition();
             propertyDefinition.PageTypePropertyAttribute.DefaultValueType = defaultValueType;
+
+            // As we have had to modifiy how default value and value types are handled in definition update
+            // we now have to specify a default value to satisfy this test
+            propertyDefinition.PageTypePropertyAttribute.DefaultValue = "true";
 
             pageDefinitionUpdater.UpdateExistingPageDefinition(pageDefinitionToUpdate, propertyDefinition);
 

--- a/PageTypeBuilder.Tests/Synchronization/PageDefinitionTypeMapperTests.cs
+++ b/PageTypeBuilder.Tests/Synchronization/PageDefinitionTypeMapperTests.cs
@@ -107,7 +107,7 @@ namespace PageTypeBuilder.Tests.Synchronization
             PageDefinitionTypeMapper mapper = new PageDefinitionTypeMapper(null, new NativePageDefinitionsMap());
             Type unmappedType = typeof(StringBuilder);
             PageTypePropertyDefinition definition = new PageTypePropertyDefinition(
-                TestValueUtility.CreateRandomString(), unmappedType, new NativePageType(), new PageTypePropertyAttribute());
+                TestValueUtility.CreateRandomString(), unmappedType, new NativePageType(), new PageTypePropertyAttribute(), null);
 
             Exception exception = Record.Exception(() => { mapper.GetPageDefinitionType(definition); });
 

--- a/PageTypeBuilder.Tests/Synchronization/PageTypePropertyDefinitionExtensionsTests.cs
+++ b/PageTypeBuilder.Tests/Synchronization/PageTypePropertyDefinitionExtensionsTests.cs
@@ -1,22 +1,20 @@
-﻿using EPiServer.DataAbstraction;
-using PageTypeBuilder.Abstractions;
-using PageTypeBuilder.Discovery;
-using PageTypeBuilder.Synchronization;
-using PageTypeBuilder.Synchronization.PageDefinitionSynchronization;
-using Xunit;
-
-namespace PageTypeBuilder.Tests.Synchronization
+﻿namespace PageTypeBuilder.Tests.Synchronization
 {
+    using Abstractions;
+    using PageTypeBuilder.Discovery;
+    using PageTypeBuilder.Synchronization.PageDefinitionSynchronization;
+    using Xunit;
+
     public class PageTypePropertyDefinitionExtensionsTests
     {
         [Fact]
         public void GivenPageTypePropertyDefinitionWithNoEditCaption_GetEditCaptionOrName_ReturnsName()
         {
             string propertyName = TestValueUtility.CreateRandomString();
-            PageTypePropertyDefinition definition = 
-                new PageTypePropertyDefinition(propertyName, typeof(string), new NativePageType(), new PageTypePropertyAttribute());
+            PageTypePropertyDefinition definition =
+                new PageTypePropertyDefinition(propertyName, typeof(string), new NativePageType(), new PageTypePropertyAttribute(), null);
 
-            string returnedEditCaption = definition.GetEditCaptionOrName();
+            string returnedEditCaption = definition.GetEditCaptionOrName(false);
 
             Assert.Equal<string>(propertyName, returnedEditCaption);
         }
@@ -25,12 +23,11 @@ namespace PageTypeBuilder.Tests.Synchronization
         public void GivenPageTypePropertyDefinitionWithEditCaption_GetEditCaptionOrName_ReturnsEditCaptionFromAttribute()
         {
             PageTypePropertyDefinition definition =
-                new PageTypePropertyDefinition(
-                    TestValueUtility.CreateRandomString(), typeof(string), new NativePageType(), new PageTypePropertyAttribute());
+                new PageTypePropertyDefinition(TestValueUtility.CreateRandomString(), typeof(string), new NativePageType(), new PageTypePropertyAttribute(), null);
             string editCaption = TestValueUtility.CreateRandomString();
             definition.PageTypePropertyAttribute.EditCaption = editCaption;
 
-            string returnedEditCaption = definition.GetEditCaptionOrName();
+            string returnedEditCaption = definition.GetEditCaptionOrName(false);
 
             Assert.Equal<string>(editCaption, returnedEditCaption);
         }

--- a/PageTypeBuilder/Activation/PageTypePropertiesProxyGenerationHook.cs
+++ b/PageTypeBuilder/Activation/PageTypePropertiesProxyGenerationHook.cs
@@ -17,6 +17,7 @@ namespace PageTypeBuilder.Activation
         public bool ShouldInterceptMethod(Type type, System.Reflection.MethodInfo memberInfo)
         {
             return memberInfo.IsGetterOrSetterForPropertyWithAttribute(typeof(PageTypePropertyAttribute))
+                && !memberInfo.IsGetterOrSetterForPropertyWithAttribute(typeof(PageTypePropertyGroupPropertyOverrideAttribute))
                 && memberInfo.IsCompilerGenerated();
         }
 
@@ -26,7 +27,7 @@ namespace PageTypeBuilder.Activation
 
         public override bool Equals(object obj)
         {
-            return ((obj != null) && (obj.GetType() == typeof(PageTypePropertiesProxyGenerationHook))); 
+            return ((obj != null) && (obj.GetType() == typeof(PageTypePropertiesProxyGenerationHook)));
         }
 
         public override int GetHashCode()

--- a/PageTypeBuilder/Configuration/PageTypeBuilderConfiguration.cs
+++ b/PageTypeBuilder/Configuration/PageTypeBuilderConfiguration.cs
@@ -1,17 +1,27 @@
-﻿using System.Configuration;
+﻿using System.Collections.Generic;
+using System.Configuration;
 
 namespace PageTypeBuilder.Configuration
 {
     public class PageTypeBuilderConfiguration : ConfigurationSection
     {
+
+        public enum AssemblyVersionStamp
+        {
+            LastWriteTime,
+            Version
+        }
+
+        private static PageTypeBuilderConfiguration _configuration;
+
         public static PageTypeBuilderConfiguration GetConfiguration()
         {
-            PageTypeBuilderConfiguration configuration = ConfigurationManager.GetSection("pageTypeBuilder") as PageTypeBuilderConfiguration;
+            if (_configuration != null)
+                return _configuration;
 
-            if (configuration != null)
-                return configuration;
+            _configuration = ConfigurationManager.GetSection("pageTypeBuilder") as PageTypeBuilderConfiguration;
 
-            return new PageTypeBuilderConfiguration();
+            return _configuration ?? new PageTypeBuilderConfiguration();
         }
 
         [ConfigurationProperty("disablePageTypeUpdation", IsRequired = false)]
@@ -23,6 +33,68 @@ namespace PageTypeBuilder.Configuration
             }
         }
 
+        [ConfigurationProperty("oneTimeSynchornizationEnabled", IsRequired = false)]
+        public virtual bool OneTimeSynchornizationEnabled
+        {
+            get
+            {
+                return (bool)this["oneTimeSynchornizationEnabled"];
+            }
+        }
+
+        [ConfigurationProperty("oneTimeSynchornizationPollTime", IsRequired = false, DefaultValue = 2000)]
+        public virtual int OneTimeSynchornizationPollTime
+        {
+            get
+            {
+                return (int)this["oneTimeSynchornizationPollTime"];
+            }
+        }
+
+        [ConfigurationProperty("oneTimeSynchronizationLogFileDirectoryPath", IsRequired = false, DefaultValue = "")]
+        public virtual string OneTimeSynchronizationLogFileDirectoryPath
+        {
+            get
+            {
+                return (string)this["oneTimeSynchronizationLogFileDirectoryPath"];
+            }
+        }
+
+        [ConfigurationProperty("oneTimeSynchronizationAssemblyVersionStamp", IsRequired = false, DefaultValue = AssemblyVersionStamp.Version)]
+        public virtual AssemblyVersionStamp OneVersionSynchronizationAssemblyVersionStamp
+        {
+            get
+            {
+                return (AssemblyVersionStamp)this["oneTimeSynchronizationAssemblyVersionStamp"];
+            }
+        }
+
+        [ConfigurationProperty("timingsLogFileDirectoryPath", IsRequired = false, DefaultValue = "")]
+        public virtual string TimingsLogFileDirectoryPath
+        {
+            get
+            {
+                return (string)this["timingsLogFileDirectoryPath"];
+            }
+        }
+
+        [ConfigurationProperty("performValidation", IsRequired = false, DefaultValue = true)]
+        public virtual bool PerformValidation
+        {
+            get
+            {
+                return (bool)this["performValidation"];
+            }
+        }
+
+        [ConfigurationProperty("scanAssemblies", IsRequired = false)]
+        public ScanAssemblyCollection ScanAssemblies
+        {
+
+            get { return ((ScanAssemblyCollection)(this["scanAssemblies"])); }
+
+        }
+
         [ConfigurationProperty("xmlns", IsRequired = false)]
         public string XmlNamespace
         {
@@ -32,4 +104,47 @@ namespace PageTypeBuilder.Configuration
             }
         }
     }
+
+    [ConfigurationCollection(typeof(ScanAssemblyElement))]
+    public class ScanAssemblyCollection : ConfigurationElementCollection
+    {
+
+        List<ScanAssemblyElement> _elements = new List<ScanAssemblyElement>();
+
+        protected override ConfigurationElement CreateNewElement()
+        {
+            ScanAssemblyElement newElement = new ScanAssemblyElement();
+            _elements.Add(newElement);
+            return newElement;
+        }
+
+        protected override object GetElementKey(ConfigurationElement element)
+        {
+            return _elements.Find(e => e.Equals(element));
+        }
+
+        public new IEnumerator<ScanAssemblyElement> GetEnumerator()
+        {
+            return _elements.GetEnumerator();
+        }
+
+    }
+
+    public class ScanAssemblyElement : ConfigurationElement
+    {
+
+        [ConfigurationProperty("assemblyName", IsKey = true, IsRequired = true)]
+        public string AssemblyName
+        {
+            get
+            {
+                return ((string)(base["assemblyName"]));
+            }
+            set
+            {
+                base["assemblyName"] = value;
+            }
+        }
+    }
+
 }

--- a/PageTypeBuilder/Discovery/PageTypePropertyDefinition.cs
+++ b/PageTypeBuilder/Discovery/PageTypePropertyDefinition.cs
@@ -1,22 +1,24 @@
-﻿using System;
-using EPiServer.DataAbstraction;
-using PageTypeBuilder.Abstractions;
-
-namespace PageTypeBuilder.Discovery
+﻿namespace PageTypeBuilder.Discovery
 {
+    using System;
+    using Abstractions;
+
     public class PageTypePropertyDefinition
     {
-        public PageTypePropertyDefinition(string name, Type propertyType, IPageType pageType, PageTypePropertyAttribute pageTypePropertyAttribute)
+        public PageTypePropertyDefinition(string name, Type propertyType, IPageType pageType, PageTypePropertyAttribute pageTypePropertyAttribute,
+            PageTypePropertyGroupPropertyOverrideAttribute pageTypePropertyGroupPropertyOverrideAttribute)
         {
             Name = name;
             PropertyType = propertyType;
             PageType = pageType;
             PageTypePropertyAttribute = pageTypePropertyAttribute;
+            PageTypePropertyGroupPropertyOverrideAttribute = pageTypePropertyGroupPropertyOverrideAttribute;
         }
 
         public string Name { get; set; }
         public Type PropertyType { get; set; }
         public IPageType PageType { get; set; }
         public PageTypePropertyAttribute PageTypePropertyAttribute { get; set; }
+        public PageTypePropertyGroupPropertyOverrideAttribute PageTypePropertyGroupPropertyOverrideAttribute { get; set; }
     }
 }

--- a/PageTypeBuilder/Discovery/TabLocator.cs
+++ b/PageTypeBuilder/Discovery/TabLocator.cs
@@ -9,6 +9,11 @@ namespace PageTypeBuilder.Discovery
     {
         private IAssemblyLocator assemblyLocator;
 
+        public IAssemblyLocator AssemblyLocator
+        {
+            get { return assemblyLocator; }
+        }
+
         public TabLocator(IAssemblyLocator assemblyLocator)
         {
             this.assemblyLocator = assemblyLocator;

--- a/PageTypeBuilder/Initializer.cs
+++ b/PageTypeBuilder/Initializer.cs
@@ -1,20 +1,15 @@
-﻿using Autofac;
-using EPiServer;
-using EPiServer.Core.PropertySettings;
-using EPiServer.Framework;
-using EPiServer.Framework.Initialization;
-using PageTypeBuilder.Abstractions;
-using PageTypeBuilder.Configuration;
-using PageTypeBuilder.Discovery;
-using PageTypeBuilder.Reflection;
-using PageTypeBuilder.Synchronization;
-using PageTypeBuilder.Synchronization.Validation;
-using InitializationModule=EPiServer.Web.InitializationModule;
-
-namespace PageTypeBuilder
+﻿namespace PageTypeBuilder
 {
+    using Autofac;
+    using EPiServer;
+    using EPiServer.Framework;
+    using EPiServer.Framework.Initialization;
+    using Configuration;
+    using Synchronization;
+    using InitializationModule = EPiServer.Web.InitializationModule;
+
     [ModuleDependency(typeof(InitializationModule))]
-    public class Initializer : IInitializableModule 
+    public class Initializer : IInitializableModule
     {
         public void Initialize(InitializationEngine context)
         {
@@ -22,9 +17,14 @@ namespace PageTypeBuilder
             var defaultBootstrapper = new DefaultBootstrapper();
             defaultBootstrapper.Configure(containerBuilder);
             var container = containerBuilder.Build();
-            
+
             PageTypeSynchronizer synchronizer = container.Resolve<PageTypeSynchronizer>();
-            synchronizer.SynchronizePageTypes();
+            TimingsLogger.Clear();
+
+            using (new TimingsLogger("Total time to synchronize"))
+            {
+                synchronizer.SynchronizePageTypes();
+            }
 
             DataFactory.Instance.LoadedPage += DataFactory_LoadedPage;
             DataFactory.Instance.LoadedChildren += DataFactory_LoadedChildren;
@@ -45,7 +45,7 @@ namespace PageTypeBuilder
 
         static void DataFactory_LoadedPage(object sender, PageEventArgs e)
         {
-            if(e.Page == null)
+            if (e.Page == null)
                 return;
 
             e.Page = PageTypeResolver.Instance.ConvertToTyped(e.Page);

--- a/PageTypeBuilder/PageTypeBuilder.csproj
+++ b/PageTypeBuilder/PageTypeBuilder.csproj
@@ -146,6 +146,7 @@
     <Compile Include="PageTypePropertyGroupAttribute.cs" />
     <Compile Include="PageTypePropertyGroupExtensions.cs" />
     <Compile Include="PageTypePropertyGroupHierarchy.cs" />
+    <Compile Include="PageTypePropertyGroupPropertyOverrideAttribute.cs" />
     <Compile Include="Reflection\AppDomainAssemblyLocator.cs" />
     <Compile Include="Reflection\AssemblyExtensions.cs" />
     <Compile Include="Reflection\IAssemblyLocator.cs" />

--- a/PageTypeBuilder/PageTypeBuilder.csproj
+++ b/PageTypeBuilder/PageTypeBuilder.csproj
@@ -75,6 +75,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>c:\Program Files (x86)\EPiServer\CMS\6.0.530.0\bin\EPiServer.BaseLibrary.dll</HintPath>
     </Reference>
+    <Reference Include="EPiServer.Data, Version=6.0.318.113, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>c:\Program Files (x86)\EPiServer\Framework\6.0.318.113\bin\EPiServer.Data.dll</HintPath>
+    </Reference>
     <Reference Include="EPiServer.Framework, Version=6.0.318.113, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>c:\Program Files (x86)\EPiServer\Framework\6.0.318.113\bin\EPiServer.Framework.dll</HintPath>
@@ -160,6 +164,7 @@
     <Compile Include="Reflection\PropertyInfoExtensions.cs" />
     <Compile Include="Reflection\TypeExtensions.cs" />
     <Compile Include="Discovery\PageTypeDefinitionLocator.cs" />
+    <Compile Include="Synchronization\SynchronizationHelper.cs" />
     <Compile Include="Synchronization\GlobalPropertySettingsSynchronizer.cs" />
     <Compile Include="Synchronization\Hooks\HooksHandler.cs" />
     <Compile Include="Synchronization\Hooks\IHooksHandler.cs" />
@@ -192,6 +197,7 @@
     <Compile Include="Synchronization\TabDefinitionUpdater.cs" />
     <Compile Include="Synchronization\Validation\UnmappablePropertyTypeException.cs" />
     <Compile Include="Tab.cs" />
+    <Compile Include="TimingsLogger.cs" />
     <Compile Include="TypedPageData.cs" />
     <Compile Include="UI\EditPage.cs">
       <SubType>ASPXCodeBehind</SubType>

--- a/PageTypeBuilder/PageTypePropertyGroupPropertyOverrideAttribute.cs
+++ b/PageTypeBuilder/PageTypePropertyGroupPropertyOverrideAttribute.cs
@@ -1,0 +1,10 @@
+﻿namespace PageTypeBuilder
+{
+    using System;
+
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = true, Inherited = false)]
+    public class PageTypePropertyGroupPropertyOverrideAttribute : PageTypePropertyAttribute
+    {
+        public string PropertyName { get; set; }
+    }
+}

--- a/PageTypeBuilder/Reflection/AppDomainAssemblyLocator.cs
+++ b/PageTypeBuilder/Reflection/AppDomainAssemblyLocator.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
+using PageTypeBuilder.Configuration;
 
 namespace PageTypeBuilder.Reflection
 {
@@ -8,7 +10,13 @@ namespace PageTypeBuilder.Reflection
     {
         public IEnumerable<Assembly> GetAssemblies()
         {
-            return AppDomain.CurrentDomain.GetAssemblies();
+            ScanAssemblyCollection scanAssemblies = PageTypeBuilderConfiguration.GetConfiguration().ScanAssemblies;
+
+            if (scanAssemblies == null || scanAssemblies.Count == 0)
+                return AppDomain.CurrentDomain.GetAssemblies();
+
+            return AppDomain.CurrentDomain.GetAssemblies()
+                .Where(c => scanAssemblies.Cast<ScanAssemblyElement>().Any(a => string.Equals(c.GetName().Name, a.AssemblyName)));
         }
     }
 }

--- a/PageTypeBuilder/Reflection/TypeExtensions.cs
+++ b/PageTypeBuilder/Reflection/TypeExtensions.cs
@@ -14,7 +14,9 @@ namespace PageTypeBuilder.Reflection
 
         internal static IEnumerable<PropertyInfo> GetPageTypePropertiesOnClass(this Type pageTypeType)
         {
-            return pageTypeType.GetPublicOrPrivateProperties().Where(propertyInfo => propertyInfo.HasAttribute(typeof(PageTypePropertyAttribute)));
+            return pageTypeType.GetPublicOrPrivateProperties()
+                .Where(propertyInfo => propertyInfo.HasAttribute(typeof(PageTypePropertyAttribute)) &&
+                    !propertyInfo.HasAttribute(typeof(PageTypePropertyGroupPropertyOverrideAttribute)));
         }
 
         internal static IEnumerable<PropertyInfo> GetPageTypePropertyGroupProperties(this Type pageTypeType)

--- a/PageTypeBuilder/Synchronization/IPageDefinitionUpdater.cs
+++ b/PageTypeBuilder/Synchronization/IPageDefinitionUpdater.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using EPiServer.DataAbstraction;
 using PageTypeBuilder.Discovery;
 
@@ -5,6 +6,7 @@ namespace PageTypeBuilder.Synchronization
 {
     public interface IPageDefinitionUpdater
     {
+        List<int> UpdatedPageDefinitions { get; }
         void UpdateExistingPageDefinition(PageDefinition pageDefinition, PageTypePropertyDefinition pageTypePropertyDefinition);
         void CreateNewPageDefinition(PageTypePropertyDefinition propertyDefinition);
     }

--- a/PageTypeBuilder/Synchronization/IPageTypeLocator.cs
+++ b/PageTypeBuilder/Synchronization/IPageTypeLocator.cs
@@ -1,11 +1,11 @@
-﻿using EPiServer.DataAbstraction;
-using PageTypeBuilder.Abstractions;
+﻿using PageTypeBuilder.Abstractions;
 using PageTypeBuilder.Discovery;
 
 namespace PageTypeBuilder.Synchronization
 {
     public interface IPageTypeLocator
     {
+        IPageTypeRepository PageTypeRepository { get; }
         IPageType GetExistingPageType(PageTypeDefinition definition);
     }
 }

--- a/PageTypeBuilder/Synchronization/PageDefinitionSynchronization/PageDefinitionSynchronizationEngine.cs
+++ b/PageTypeBuilder/Synchronization/PageDefinitionSynchronization/PageDefinitionSynchronizationEngine.cs
@@ -14,6 +14,16 @@ namespace PageTypeBuilder.Synchronization.PageDefinitionSynchronization
         PageDefinitionSpecificPropertySettingsUpdater pageDefinitionSpecificPropertySettingsUpdater;
         IPageTypeRepository pageTypeRepository;
 
+        internal IPageDefinitionUpdater PageDefinitionUpdater
+        {
+            get { return pageDefinitionUpdater; }
+        }
+
+        internal PageDefinitionSpecificPropertySettingsUpdater PageDefinitionSpecificPropertySettingsUpdater
+        {
+            get { return pageDefinitionSpecificPropertySettingsUpdater; }
+        }
+
         public PageDefinitionSynchronizationEngine(
             IPageDefinitionUpdater pageDefinitionUpdater,
             PageTypePropertyDefinitionLocator pageTypePropertyDefinitionLocator,
@@ -34,10 +44,14 @@ namespace PageTypeBuilder.Synchronization.PageDefinitionSynchronization
             foreach (PageTypePropertyDefinition propertyDefinition in definitions)
             {
                 PageDefinition pageDefinition = GetExistingPageDefinition(pageType, propertyDefinition);
+             
                 if (pageDefinition == null)
                 {
-                    pageDefinitionUpdater.CreateNewPageDefinition(propertyDefinition);
-                    pageDefinition = GetExistingPageDefinition(pageType, propertyDefinition);
+                    using (new TimingsLogger(string.Format("Creating new page definition '{0}' for page type {1}: ", propertyDefinition.Name, pageType.Name)))
+                    {
+                        pageDefinitionUpdater.CreateNewPageDefinition(propertyDefinition);
+                        pageDefinition = GetExistingPageDefinition(pageType, propertyDefinition);
+                    }
                 }
                 else
                 {

--- a/PageTypeBuilder/Synchronization/PageDefinitionSynchronization/PageTypePropertyDefinitionExtensions.cs
+++ b/PageTypeBuilder/Synchronization/PageDefinitionSynchronization/PageTypePropertyDefinitionExtensions.cs
@@ -4,11 +4,14 @@ namespace PageTypeBuilder.Synchronization.PageDefinitionSynchronization
 {
     public static class PageTypePropertyDefinitionExtensions
     {
-        public static string GetEditCaptionOrName(this PageTypePropertyDefinition pageTypePropertyDefinition)
+        public static string GetEditCaptionOrName(this PageTypePropertyDefinition pageTypePropertyDefinition, bool propertyGroupOverride)
         {
             string editCaption = pageTypePropertyDefinition.PageTypePropertyAttribute.EditCaption;
-            
-            if(string.IsNullOrEmpty(editCaption))
+
+            if (propertyGroupOverride && pageTypePropertyDefinition.PageTypePropertyGroupPropertyOverrideAttribute.EditCaptionSet)
+                editCaption = pageTypePropertyDefinition.PageTypePropertyGroupPropertyOverrideAttribute.EditCaption;
+
+            if (string.IsNullOrEmpty(editCaption))
                 editCaption = pageTypePropertyDefinition.Name;
 
             return editCaption;

--- a/PageTypeBuilder/Synchronization/PageTypeLocator.cs
+++ b/PageTypeBuilder/Synchronization/PageTypeLocator.cs
@@ -8,6 +8,11 @@ namespace PageTypeBuilder.Synchronization
     {
         private IPageTypeRepository pageTypeRepository;
 
+        public IPageTypeRepository PageTypeRepository
+        {
+            get { return pageTypeRepository; }
+        }
+
         public PageTypeLocator(IPageTypeRepository pageTypeRepository)
         {
             this.pageTypeRepository = pageTypeRepository;
@@ -19,21 +24,16 @@ namespace PageTypeBuilder.Synchronization
             Type type = definition.Type;
             PageTypeAttribute attribute = definition.Attribute;
             if (attribute.Guid.HasValue)
-            {
                 existingPageType = pageTypeRepository.Load(attribute.Guid.Value);
-            }
 
             if (existingPageType == null && attribute.Name != null)
-            {
                 existingPageType = pageTypeRepository.Load(attribute.Name);
-            }
 
             if (existingPageType == null)
-            {
                 existingPageType = pageTypeRepository.Load(type.Name);
-            }
 
-            return existingPageType;
+            return existingPageType; 
         }
+
     }
 }

--- a/PageTypeBuilder/Synchronization/PageTypeSynchronizer.cs
+++ b/PageTypeBuilder/Synchronization/PageTypeSynchronizer.cs
@@ -1,14 +1,16 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using PageTypeBuilder.Abstractions;
-using PageTypeBuilder.Configuration;
-using PageTypeBuilder.Discovery;
-using PageTypeBuilder.Synchronization.Hooks;
-using PageTypeBuilder.Synchronization.PageDefinitionSynchronization;
-using PageTypeBuilder.Synchronization.Validation;
-
-namespace PageTypeBuilder.Synchronization
+﻿namespace PageTypeBuilder.Synchronization
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using Abstractions;
+    using Configuration;
+    using Discovery;
+    using Hooks;
+    using PageDefinitionSynchronization;
+    using Validation;
+
     public class PageTypeSynchronizer
     {
         private IPageTypeLocator _pageTypeLocator;
@@ -33,7 +35,12 @@ namespace PageTypeBuilder.Synchronization
             this.pageTypeResolver = pageTypeResolver;
             TabLocator = tabLocator;
             TabDefinitionUpdater = tabDefinitionUpdater;
-            _pageTypeDefinitions = pageTypeDefinitionLocator.GetPageTypeDefinitions();
+
+            using (new TimingsLogger("Getting page type definitions"))
+            {
+                _pageTypeDefinitions = pageTypeDefinitionLocator.GetPageTypeDefinitions();
+            }
+
             PageTypeUpdater = pageTypeUpdater;
             PageDefinitionSynchronizationEngine = pageDefinitionSynchronizationEngine;
             PageTypeDefinitionValidator = pageTypeDefinitionValidator;
@@ -42,35 +49,124 @@ namespace PageTypeBuilder.Synchronization
             this.hooksHandler = hooksHandler;
         }
 
-        internal void SynchronizePageTypes()
+
+        public void SynchronizePageTypes()
         {
-            hooksHandler.InvokePreSynchronizationHooks();
+            SynchronizePageTypes(false);
+        }
 
-            if (!_configuration.DisablePageTypeUpdation)
+        public void SynchronizePageTypes(bool forcePageTypeUpdation)
+        {
+            SynchronizationHelper.AssemblyLocator = TabLocator.AssemblyLocator;
+            bool disablePageTypeUpdation = _configuration.DisablePageTypeUpdation;
+
+            if (forcePageTypeUpdation)
+                disablePageTypeUpdation = false;
+
+            bool oneTimeSynchornizationEnabled = !disablePageTypeUpdation && SynchronizationHelper.OneTimeSynchornizationEnabled;
+            bool iAmSynching = true;
+            
+            if (oneTimeSynchornizationEnabled)
             {
-                UpdateTabDefinitions();
-                globalPropertySettingsSynchronizer.Synchronize();
+                SynchronizationHelper.ClearLogInfo();
+                bool isBeingSynchronized = SynchronizationHelper.IsBeingSynchronized(out iAmSynching);
+
+                if (isBeingSynchronized && !iAmSynching)
+                {
+                    using (new TimingsLogger("Waiting for synchornization to finish on synching site."))
+                    {
+                        while (SynchronizationHelper.IsBeingSynchronized(out iAmSynching))
+                            Thread.Sleep(_configuration.OneTimeSynchornizationPollTime);
+                    }
+                }
             }
 
-            IEnumerable<PageTypeDefinition> pageTypeDefinitions = _pageTypeDefinitions;
-
-            ValidatePageTypeDefinitions(pageTypeDefinitions);
-
-            if (!_configuration.DisablePageTypeUpdation)
-                CreateNonExistingPageTypes(pageTypeDefinitions);
-
-            if (_configuration.DisablePageTypeUpdation)
+            try
             {
-                IEnumerable<PageTypeDefinition> nonExistingPageTypes = GetNonExistingPageTypes(pageTypeDefinitions);
-                pageTypeDefinitions = pageTypeDefinitions.Except(nonExistingPageTypes).ToList();
-            }
-            else
-            {
-                UpdatePageTypes(pageTypeDefinitions);
-                UpdatePageTypePropertyDefinitions(pageTypeDefinitions);
-            }
+                using (new TimingsLogger("Pre synchoronization hooks"))
+                {
+                    if (iAmSynching)
+                        hooksHandler.InvokePreSynchronizationHooks();
+                }
 
-            AddPageTypesToResolver(pageTypeDefinitions);
+                if (!disablePageTypeUpdation && iAmSynching)
+                {
+                    using (new TimingsLogger("updating tab definitions"))
+                    {
+                        UpdateTabDefinitions();
+                    }
+
+                    using (new TimingsLogger("updating global property settings"))
+                    {
+                        globalPropertySettingsSynchronizer.Synchronize();
+                    }
+                }
+
+                IEnumerable<PageTypeDefinition> pageTypeDefinitions = _pageTypeDefinitions.ToList();
+
+                if (!disablePageTypeUpdation && _configuration.PerformValidation && iAmSynching)
+                {
+                    using (new TimingsLogger("Validating page type definitions"))
+                    {
+                        ValidatePageTypeDefinitions(pageTypeDefinitions);
+                    }
+                }
+
+                if (!disablePageTypeUpdation && iAmSynching)
+                {
+                    using (new TimingsLogger("Creating non existing page types"))
+                    {
+                        CreateNonExistingPageTypes(pageTypeDefinitions);
+                    }
+                }
+
+                if (disablePageTypeUpdation || !iAmSynching)
+                {
+                    using (new TimingsLogger("Getting non existing page types"))
+                    {
+                        IEnumerable<PageTypeDefinition> nonExistingPageTypes = GetNonExistingPageTypes(pageTypeDefinitions);
+                        pageTypeDefinitions = pageTypeDefinitions.Except(nonExistingPageTypes).ToList();
+                    }
+                }
+                else
+                {
+                    using (new TimingsLogger("Updating page types"))
+                    {
+                        UpdatePageTypes(pageTypeDefinitions);
+                    }
+
+                    using (new TimingsLogger("Updating page type property definitions"))
+                    {
+                        UpdatePageTypePropertyDefinitions(pageTypeDefinitions);
+                    }
+                }
+
+                using (new TimingsLogger("Adding page types to resolver"))
+                {
+                    AddPageTypesToResolver(pageTypeDefinitions);
+                }
+
+                if (oneTimeSynchornizationEnabled && iAmSynching)
+                {
+                    SynchronizationHelper.UpateSynchronizationCache(PageTypeUpdater.UpdatedPageTypeIds, 
+                        PageDefinitionSynchronizationEngine.PageDefinitionUpdater.UpdatedPageDefinitions,
+                        TabDefinitionUpdater.updatedTabIds,
+                        PageDefinitionSynchronizationEngine.PageDefinitionSpecificPropertySettingsUpdater.updatedPropertySettingsCacheKeys,
+                        globalPropertySettingsSynchronizer.globalSettingsIds);
+
+                    SynchronizationHelper.SynchingComplete();
+                }
+
+                if (oneTimeSynchornizationEnabled && !iAmSynching)
+                    SynchronizationHelper.InvalidateCache();
+            }
+            catch (Exception)
+            {
+                if (oneTimeSynchornizationEnabled && iAmSynching)
+                    SynchronizationHelper.RevertSyncronizationStatus();
+
+                throw;
+            }
         }
 
         protected internal virtual void UpdateTabDefinitions()
@@ -86,10 +182,18 @@ namespace PageTypeBuilder.Synchronization
 
         protected internal virtual void CreateNonExistingPageTypes(IEnumerable<PageTypeDefinition> pageTypeDefinitions)
         {
-            IEnumerable<PageTypeDefinition> nonExistingPageTypes = GetNonExistingPageTypes(pageTypeDefinitions);
+            IEnumerable<PageTypeDefinition> nonExistingPageTypes;
+            
+            using (new TimingsLogger("GetNonExistingPageTypes"))
+            {
+                nonExistingPageTypes = GetNonExistingPageTypes(pageTypeDefinitions).ToList();
+            }
 
-            foreach (PageTypeDefinition definition in nonExistingPageTypes)
-                PageTypeUpdater.CreateNewPageType(definition);
+            using (new TimingsLogger("PageTypeUpdater.CreateNewPageTypes"))
+            {
+                foreach (PageTypeDefinition definition in nonExistingPageTypes)
+                    PageTypeUpdater.CreateNewPageType(definition);
+            }
         }
 
         protected internal virtual IEnumerable<PageTypeDefinition> GetNonExistingPageTypes(IEnumerable<PageTypeDefinition> pageTypeDefinitions)

--- a/PageTypeBuilder/Synchronization/PageTypeSynchronizer.cs
+++ b/PageTypeBuilder/Synchronization/PageTypeSynchronizer.cs
@@ -75,7 +75,7 @@
                 {
                     using (new TimingsLogger("Waiting for synchornization to finish on synching site."))
                     {
-                        while (SynchronizationHelper.IsBeingSynchronized(out iAmSynching))
+                        while (SynchronizationHelper.IsBeingSynchronized(out iAmSynching) && !iAmSynching)
                             Thread.Sleep(_configuration.OneTimeSynchornizationPollTime);
                     }
                 }

--- a/PageTypeBuilder/Synchronization/SynchronizationHelper.cs
+++ b/PageTypeBuilder/Synchronization/SynchronizationHelper.cs
@@ -1,0 +1,419 @@
+﻿namespace PageTypeBuilder.Synchronization
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Configuration;
+    using System.Data;
+    using System.Data.SqlClient;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using System.Text;
+    using System.Web.Hosting;
+    using Configuration;
+    using EPiServer.Data.Cache;
+    using Reflection;
+
+    internal static class SynchronizationHelper
+    {
+        private static readonly Guid SyncGuid = new Guid("14f94889-d8e3-4294-b84f-9c5d990b019d");
+        private static readonly Guid SyncCacheGuid = new Guid("9F85BF43-2509-48B6-AE3D-B75DE9918542");
+        private const string SynchornizingStatusText = "Synchornizing";
+        private const string PageTypeBuilderSynchornization = "PageTypeBuilderSynchornization";
+        private const string ConnectionStringName = "EPiServerDB";
+        private static string _siteId;
+        private static DirectoryInfo _logFileDirectory;
+        private static bool _logFileDirectoryRetrieved;
+
+        public static bool OneTimeSynchornizationEnabled
+        {
+            get
+            {
+                return PageTypeBuilderConfiguration.GetConfiguration().OneTimeSynchornizationEnabled &&
+                       ConfigurationManager.ConnectionStrings[ConnectionStringName].ProviderName.Equals("System.Data.SqlClient");
+            }
+        }
+
+        public static IAssemblyLocator AssemblyLocator { get; set; }
+
+        public static bool IsBeingSynchronized(out bool iAmSynching)
+        {
+            LogInfo("Checking whether synchornization is in progress");
+            iAmSynching = false;
+            bool isBeingSynchronized = false;
+
+            try
+            {
+                using (SqlConnection connection = new SqlConnection(ConfigurationManager.ConnectionStrings[ConnectionStringName].ConnectionString))
+                {
+                    connection.Open();
+                    bool commit = false;
+
+                    using (SqlTransaction transaction = connection.BeginTransaction())
+                    {
+                        string sql = string.Format("SELECT COUNT(*) FROM tblItem WITH (TABLOCKX) WHERE pkID = '{0}'", SyncGuid);
+
+                        using (SqlCommand command = new SqlCommand(sql, connection, transaction))
+                        {
+                            int count = (int)command.ExecuteScalar();
+
+                            if (count == 0)
+                            {
+                                LogInfo("Creating new record in tblItem as we are now synching");
+                                SaveSynchornizationStatus(connection, transaction, SyncGuid, Encoding.UTF8.GetBytes(SynchornizingStatusText));
+                                iAmSynching = true;
+                                isBeingSynchronized = true;
+                                commit = true;
+                            }
+                            else
+                            {
+                                string value = GetSynchornizationStatus(connection, transaction, SyncGuid);
+
+                                if (value.Trim() == SynchornizingStatusText)
+                                {
+                                    LogInfo("Already being synched by another site");
+                                    isBeingSynchronized = true;
+                                }
+                                else
+                                {
+                                    string timestamps = GetAssemblyTimeStamps();
+
+                                    LogInfo("current application assembly timestamps: " + timestamps + "|");
+                                    LogInfo("current timestamps in database:" + value.Trim() + "|");
+
+                                    if (!string.Equals(value.Trim(), timestamps))
+                                    {
+                                        LogInfo("time stamps have changed, so now synching");
+                                        SaveSynchornizationStatus(connection, transaction, SyncGuid, Encoding.UTF8.GetBytes(SynchornizingStatusText));
+                                        iAmSynching = true;
+                                        isBeingSynchronized = true;
+                                        commit = true;
+                                    }
+                                }
+                            }
+                        }
+
+                        if (commit)
+                            transaction.Commit();
+                        else
+                            transaction.Rollback();
+                    }
+
+                    connection.Close();
+                }
+            }
+            catch (Exception)
+            {
+                RevertSyncronizationStatus();
+                throw;
+            }
+            return isBeingSynchronized;
+        }
+
+        public static void SynchingComplete()
+        {
+            try
+            {
+                using (SqlConnection connection = new SqlConnection(ConfigurationManager.ConnectionStrings[ConnectionStringName].ConnectionString))
+                {
+                    connection.Open();
+
+                    using (SqlTransaction transaction = connection.BeginTransaction())
+                    {
+                        string sql = string.Format("SELECT COUNT(*) FROM tblItem WITH (TABLOCKX) WHERE pkID = '{0}'", SyncGuid);
+
+                        using (SqlCommand command = new SqlCommand(sql, connection, transaction))
+                        {
+                            command.ExecuteScalar();
+                            SaveSynchornizationStatus(connection, transaction, SyncGuid, Encoding.UTF8.GetBytes(GetAssemblyTimeStamps()));
+                            LogInfo("Updated timestamps with value: " + GetAssemblyTimeStamps());
+                        }
+
+                        transaction.Commit();
+                    }
+
+                    connection.Close();
+                }
+            }
+            catch (Exception)
+            {
+                RevertSyncronizationStatus();
+                throw;
+            }
+        }
+
+        private static void SaveSynchornizationStatus(SqlConnection connection, SqlTransaction transaction, Guid id, byte[] data)
+        {
+            using (SqlCommand command = new SqlCommand("[dbo].[ItemSave]", connection, transaction))
+            {
+                command.CommandType = CommandType.StoredProcedure;
+                command.Parameters.AddWithValue("@Id", id.ToString());
+                command.Parameters.AddWithValue("@DbSchemaId", 1);
+                command.Parameters.AddWithValue("@Name", PageTypeBuilderSynchornization);
+                command.Parameters.Add("@ItemData", SqlDbType.Image);
+                command.Parameters["@ItemData"].Value = data;
+                command.ExecuteNonQuery();
+            }
+        }
+
+        private static string GetSynchornizationStatus(SqlConnection connection, SqlTransaction transaction, Guid id)
+        {
+            using (SqlCommand command = new SqlCommand("[dbo].[ItemLoad]", connection, transaction))
+            {
+                command.CommandType = CommandType.StoredProcedure;
+                command.Parameters.AddWithValue("@Id", id.ToString());
+                byte[] bytes = (byte[])command.ExecuteScalar();
+                string value = Encoding.UTF8.GetString(bytes);
+                LogInfo("tblItem value is currently: " + value);
+                return value;
+            }
+        }
+
+        public static void RevertSyncronizationStatus()
+        {
+            using (SqlConnection connection = new SqlConnection(ConfigurationManager.ConnectionStrings[ConnectionStringName].ConnectionString))
+            {
+                connection.Open();
+
+                using (SqlTransaction transaction = connection.BeginTransaction())
+                {
+                    string sql = string.Format("SELECT COUNT(*) FROM tblItem WITH (TABLOCKX) WHERE pkID = '{0}'", SyncGuid);
+
+                    using (SqlCommand command = new SqlCommand(sql, connection, transaction))
+                    {
+                        command.ExecuteScalar();
+                        SaveSynchornizationStatus(connection, transaction, SyncGuid, new byte[0]);
+                        LogInfo("Reverted synchronization status.");
+                    }
+
+                    transaction.Commit();
+                }
+
+                connection.Close();
+            }
+        }
+
+        public static void UpateSynchronizationCache(List<int> pageTypeIds, List<int> pageDefinitionIds, List<int> updatedTabDefinitionIds,
+            List<string> updatedPropertySettingsCacheKeys, List<Guid> globalPropertySettingsIds)
+        {
+            try
+            {
+                StringBuilder stringBuilder = new StringBuilder();
+                AppendItems(stringBuilder, "pageTypeIds", pageTypeIds.Select(c => c as object).ToArray());
+                AppendItems(stringBuilder, "pageDefinitionIds", pageDefinitionIds.Select(c => c as object).ToArray());
+                AppendItems(stringBuilder, "tabDefinitionIds", updatedTabDefinitionIds.Select(c => c as object).ToArray());
+                AppendItems(stringBuilder, "updatedPropertySettingsCacheKeys", updatedPropertySettingsCacheKeys.Select(c => c as object).ToArray());
+                AppendItems(stringBuilder, "updatedGlobalPropertySettingsIds", globalPropertySettingsIds.Select(c => c as object).ToArray());
+
+                using (SqlConnection connection = new SqlConnection(ConfigurationManager.ConnectionStrings[ConnectionStringName].ConnectionString))
+                {
+                    connection.Open();
+                    SaveSynchornizationStatus(connection, null, SyncCacheGuid, Encoding.UTF8.GetBytes(stringBuilder.ToString()));
+                    connection.Close();
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private static void AppendItems(StringBuilder stringBuilder, string key, IEnumerable<object> items)
+        {
+            stringBuilder.AppendFormat("{0}:", key);
+
+            foreach (object item in items)
+                stringBuilder.AppendFormat("{0}|", item);
+
+            stringBuilder.AppendLine();
+        }
+
+        public static void InvalidateCache()
+        {
+            string value = string.Empty;
+
+            using (SqlConnection connection = new SqlConnection(ConfigurationManager.ConnectionStrings[ConnectionStringName].ConnectionString))
+            {
+                connection.Open();
+                value = GetSynchornizationStatus(connection, null, SyncCacheGuid);
+                connection.Close();
+            }
+
+            if (string.IsNullOrEmpty(value))
+                return;
+
+            string[] parts = value.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            string part;
+
+            // page types
+            if (!string.IsNullOrEmpty(part = GetCacheInvalidationKeyPart(parts, "pageTypeIds", 0)))
+            {
+                IEnumerable<int> pageTypeIds = part.Split(new[] {'|'}, StringSplitOptions.RemoveEmptyEntries).Select(int.Parse);
+
+                if (pageTypeIds.Any())
+                    EPiServer.DataAbstraction.PageType.ClearCache();
+            }
+
+            // page definitions
+            if (!string.IsNullOrEmpty(part = GetCacheInvalidationKeyPart(parts, "pageDefinitionIds", 1)))
+            {
+                List<int> pageDefinitionIds = part.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries).Select(int.Parse).ToList();
+
+                if (pageDefinitionIds.Any())
+                {
+                    foreach (int pageDefinitionId in pageDefinitionIds)
+                    {
+                        try
+                        {
+                            EPiServer.DataAbstraction.PageDefinition pageDefinition = EPiServer.DataAbstraction.PageDefinition.Load(pageDefinitionId);
+                            pageDefinition.ClearCache();
+                        }
+                        catch
+                        {
+                        }
+                    }
+                }
+            }
+
+            // tab definitions
+            if (!string.IsNullOrEmpty(part = GetCacheInvalidationKeyPart(parts, "tabDefinitionIds", 2)))
+            {
+                IEnumerable<int> tabDefinitionIds = part.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries).Select(int.Parse);
+
+                if (tabDefinitionIds.Any())
+                    EPiServer.DataAbstraction.TabDefinition.ClearCache();
+            }
+
+            // property settings and property settings referencing global
+            if (!string.IsNullOrEmpty(part = GetCacheInvalidationKeyPart(parts, "updatedPropertySettingsCacheKeys", 3)))
+            {
+                List<string> cacheKeys = part.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries).ToList();
+
+                foreach (string cacheKey in cacheKeys)
+                    EPiServer.CacheManager.Remove(cacheKey);
+            }
+
+            // global property settings
+            if (!string.IsNullOrEmpty(part = GetCacheInvalidationKeyPart(parts, "updatedGlobalPropertySettingsIds", 4)))
+            {
+                IEnumerable<Guid> ids = part.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries).Select(c => new Guid(c));
+
+                foreach (Guid id in ids)
+                    CacheProvider.Instance.Remove(id.ToString());
+            }
+        }
+
+        private static string GetCacheInvalidationKeyPart(IList<string> parts, string key, int index)
+        {
+            if (parts.Count <= index || !parts[index].StartsWith(key + ":"))
+                return string.Empty;
+
+            return parts[index].Substring(parts[index].IndexOf(":") + 1);
+        }
+
+        private static string GetAssemblyTimeStamps()
+        {
+            StringBuilder timeStamps = new StringBuilder();
+            IEnumerable<Assembly> assemblies = AssemblyLocator.AssembliesWithReferenceToAssemblyOf<TypedPageData>();
+
+            if (PageTypeBuilderConfiguration.GetConfiguration().OneVersionSynchronizationAssemblyVersionStamp == PageTypeBuilderConfiguration.AssemblyVersionStamp.Version)
+            {
+                foreach (Assembly assembly in assemblies)
+                    timeStamps.AppendFormat("{0} - {1}|", assembly.GetName().Name, assembly.GetName().Version);
+            }
+            else
+            {
+                DirectoryInfo binDirectory = new DirectoryInfo(HostingEnvironment.MapPath("~/bin"));
+
+                foreach (FileInfo assemblyFile in binDirectory.GetFiles("*.dll")
+                   .Where(current => assemblies.Any(assembly => string.Equals(assembly.GetName().Name, current.Name.Substring(0, current.Name.Length - 4), StringComparison.OrdinalIgnoreCase)))
+                   .OrderBy(current => current.Name))
+                {
+                    timeStamps.AppendFormat("{0} - {1}|", assemblyFile.Name, assemblyFile.LastWriteTime.ToString("yyyyMMdd hh:mm:ss"));
+                }   
+            }
+
+            return timeStamps.ToString();
+        }
+
+        private static void LogInfo(string message)
+        {
+            DirectoryInfo logDirectory = GetLogDirectory();
+
+            if (logDirectory == null || !logDirectory.Exists)
+                return;
+
+            if (_siteId == null)
+                _siteId = GetSiteId();
+
+            try
+            {
+                message = string.Format("{0} - {1}: {2}{2}", DateTime.Now.ToString("dd/MM/yyyy hh:mm:ss"), message, Environment.NewLine);
+                string logFileName = GetLogFileName(logDirectory, _siteId);
+                File.AppendAllText(logFileName, message);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine("Error while trying to log messages using PageTypeBuilder.SynchronizationHelper. " + ex.Message);
+            }
+        }
+
+        public static void ClearLogInfo()
+        {
+            DirectoryInfo logDirectory = GetLogDirectory();
+
+            if (logDirectory == null || !logDirectory.Exists)
+                return;
+
+            string siteId = GetSiteId();
+            string logFileName = GetLogFileName(logDirectory, siteId);
+
+            if (!File.Exists(logFileName))
+                return;
+
+            try
+            {
+                File.Delete(logFileName);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(string.Format("Error while trying to delete file '{0}'. {1}", logFileName, ex.Message));
+            }
+        }
+
+        private static DirectoryInfo GetLogDirectory()
+        {
+            if (_logFileDirectoryRetrieved && (_logFileDirectory == null || !_logFileDirectory.Exists))
+                return null;
+
+            _logFileDirectoryRetrieved = true;
+            string directoryPath = PageTypeBuilderConfiguration.GetConfiguration().OneTimeSynchronizationLogFileDirectoryPath;
+
+            if (string.IsNullOrEmpty(directoryPath))
+                return null;
+
+            if (!directoryPath.EndsWith(@"\"))
+                directoryPath += @"\";
+
+            _logFileDirectory = new DirectoryInfo(directoryPath);
+            return !_logFileDirectory.Exists ? null : _logFileDirectory;
+        }
+
+        private static string GetSiteId()
+        {
+            try
+            {
+                return string.Format("{0}_{1}", HostingEnvironment.ApplicationHost.GetSiteName(), HostingEnvironment.ApplicationHost.GetSiteID());
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        private static string GetLogFileName(DirectoryInfo logDirectory, string siteId)
+        {
+            return string.Format("{0}PageTypeBuilderOneTimeSynchornizationLog_{1}.txt", logDirectory.FullName, siteId);
+        }
+
+    }
+}

--- a/PageTypeBuilder/Synchronization/TabDefinitionUpdater.cs
+++ b/PageTypeBuilder/Synchronization/TabDefinitionUpdater.cs
@@ -6,9 +6,13 @@ namespace PageTypeBuilder.Synchronization
 {
     public class TabDefinitionUpdater
     {
+
+        internal List<int> updatedTabIds; 
+
         public TabDefinitionUpdater(ITabDefinitionRepository tabDefinitionRepository)
         {
             TabDefinitionRepository = tabDefinitionRepository;
+            updatedTabIds = new List<int>();
         }
 
         public virtual void UpdateTabDefinitions(IEnumerable<Tab> tabs)
@@ -21,6 +25,7 @@ namespace PageTypeBuilder.Synchronization
                 {
                     UpdateTabDefinition(tabDefinition, tab);
                     TabDefinitionRepository.SaveTabDefinition(tabDefinition);
+                    updatedTabIds.Add(tabDefinition.ID);
                 }
             }
         }

--- a/PageTypeBuilder/Synchronization/Validation/PageTypeDefinitionPropertiesValidator.cs
+++ b/PageTypeBuilder/Synchronization/Validation/PageTypeDefinitionPropertiesValidator.cs
@@ -45,9 +45,7 @@ namespace PageTypeBuilder.Synchronization.Validation
         protected internal virtual void ValidatePageTypeProperty(PropertyInfo propertyInfo)
         {
             ValidateCompilerGeneratedProperty(propertyInfo);
-
             ValidatePageTypePropertyAttribute(propertyInfo);
-
             ValidatePageTypePropertyType(propertyInfo);
         }
 

--- a/PageTypeBuilder/Synchronization/Validation/PageTypeDefinitionValidator.cs.cs
+++ b/PageTypeBuilder/Synchronization/Validation/PageTypeDefinitionValidator.cs.cs
@@ -21,11 +21,17 @@ namespace PageTypeBuilder.Synchronization.Validation
 
         public virtual void ValidatePageTypeDefinitions(IEnumerable<PageTypeDefinition> pageTypeDefinitions)
         {
-            ValidatePageTypesHaveGuidOrUniqueName(pageTypeDefinitions);
-            
+            using (new TimingsLogger("ValidatePagetypesHaveGuidOrUniqueName"))
+            {
+                ValidatePageTypesHaveGuidOrUniqueName(pageTypeDefinitions);
+            }
+
             foreach (PageTypeDefinition definition in pageTypeDefinitions)
             {
-                ValidatePageTypeDefinition(definition, pageTypeDefinitions); 
+                using (new TimingsLogger("ValidatePageTypeDefinition"))
+                {
+                    ValidatePageTypeDefinition(definition, pageTypeDefinitions);
+                }
             }
         }
 
@@ -57,13 +63,9 @@ namespace PageTypeBuilder.Synchronization.Validation
         public virtual void ValidatePageTypeDefinition(PageTypeDefinition definition, IEnumerable<PageTypeDefinition> allPageTypeDefinitions)
         {
             ValidateNameLength(definition);
-
             ValidateInheritsFromBasePageType(definition);
-
             ValidateAvailablePageTypes(definition, allPageTypeDefinitions);
-
             ValidateExcludedPageTypes(definition, allPageTypeDefinitions);
-
             PropertiesValidator.ValidatePageTypeProperties(definition);
         }
 

--- a/PageTypeBuilder/TimingsLogger.cs
+++ b/PageTypeBuilder/TimingsLogger.cs
@@ -1,0 +1,100 @@
+﻿namespace PageTypeBuilder
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Web.Hosting;
+    using Configuration;
+
+    public class TimingsLogger : IDisposable
+    {
+        private readonly string _message;
+        private readonly Stopwatch _stopwatch;
+        private readonly DirectoryInfo _logDirectory;
+        private static string _siteId;
+
+        public TimingsLogger(string message)
+        {
+            _message = message;
+            _logDirectory = GetLogDirectory();
+
+            if (_logDirectory != null && _logDirectory.Exists)
+                _stopwatch = Stopwatch.StartNew();
+        }
+
+        public static void Clear()
+        {
+            DirectoryInfo logDirectory = GetLogDirectory();
+
+            if (logDirectory == null || !logDirectory.Exists)
+                return;
+
+            string siteId = GetSiteId();
+            string logFileName = GetLogFileName(logDirectory, siteId);
+
+            if (!File.Exists(logFileName)) 
+                return;
+
+            try
+            {
+                File.Delete(logFileName);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(string.Format("Error while trying to delete file '{0}'. {1}", logFileName, ex.Message));
+            }
+        }
+
+        private static DirectoryInfo GetLogDirectory()
+        {
+            string directoryPath = PageTypeBuilderConfiguration.GetConfiguration().TimingsLogFileDirectoryPath;
+
+            if (string.IsNullOrEmpty(directoryPath))
+                return null;
+
+            if (!directoryPath.EndsWith(@"\"))
+                directoryPath += @"\";
+
+            DirectoryInfo logDirectory = new DirectoryInfo(directoryPath);
+            return !logDirectory.Exists ? null : logDirectory;
+        }
+
+        private static string GetSiteId()
+        {
+            try
+            {
+                return string.Format("{0}_{1}", HostingEnvironment.ApplicationHost.GetSiteName(), HostingEnvironment.ApplicationHost.GetSiteID());
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        private static string GetLogFileName(DirectoryInfo logDirectory, string siteId)
+        {
+            return string.Format("{0}PageTypeBuilderTimingsLog_{1}.txt", logDirectory.FullName, siteId);
+        }
+
+        public void Dispose()
+        {
+            if (_logDirectory == null || !_logDirectory.Exists)
+                return;
+
+            if (_siteId == null)
+                _siteId = GetSiteId();
+
+            try
+            {
+                string message = string.Format("{0} - {1}: {2}{3}{3}", DateTime.Now.ToString("dd/MM/yyyy hh:mm:ss"), _message, _stopwatch.ElapsedMilliseconds, Environment.NewLine);
+                string logFileName = GetLogFileName(_logDirectory, _siteId);
+                File.AppendAllText(logFileName, message);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine("Error while trying to log messages using PageTypeBuilder.TimingsLogger. " + ex.Message);
+            }
+            
+        }
+    }
+}


### PR DESCRIPTION
Example usage:

[PageType]
public class TestPageType
{
    [PageTypePropertyGroup(EditCaptionPrefix = "Prefix ")]
    [PageTypePropertyGroupPropertyOverride(PropertyName = "PropertyOne", DefaultValue = "Pickle")]
    public TestPropertyGroup TestPropertyGroup { get; set; }
}

public class TestPropertyGroup : PageTypePropertyGroup
{
    [PageTypeProperty(
        Type = typeof(PropertyString, 
        SortOrder = 100,
        DefaultValue = "Cheese",
        DevaultValueType = DefaultValueType.Value)]
    public virtual string PropertyOne { get;set; }
}
